### PR TITLE
fix(agency-kyc): improve OCR extraction logging and UI field filtering

### DIFF
--- a/apps/frontend_web/app/agency/kyc/page.tsx
+++ b/apps/frontend_web/app/agency/kyc/page.tsx
@@ -1191,7 +1191,8 @@ const AgencyKYCPage = () => {
               </h2>
               <div className="space-y-4">
                 {AGENCY_KYC_FIELD_CONFIG.filter(
-                  (f) => f.section === "business",
+                  (f) => f.section === "business" &&
+                    (!f.applicableBusinessTypes || f.applicableBusinessTypes.includes(businessType)),
                 ).map((field) => (
                   <div key={field.key}>
                     <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/apps/frontend_web/lib/hooks/useAgencyKYCAutofill.ts
+++ b/apps/frontend_web/lib/hooks/useAgencyKYCAutofill.ts
@@ -19,6 +19,8 @@ export interface AgencyKYCField {
   type?: "text" | "select" | "date";
   options?: { value: string; label: string }[];
   section: "business" | "representative";
+  /** If set, field only shown for these business types. If undefined, shown for all. */
+  applicableBusinessTypes?: string[];
 }
 
 // Government ID types matching mobile app
@@ -37,6 +39,14 @@ export const ID_TYPES = [
   { value: "OTHER", label: "Other Government ID" },
 ];
 
+// Business types for conditional field rendering
+export const BUSINESS_TYPES = {
+  SOLE_PROPRIETORSHIP: "SOLE_PROPRIETORSHIP",
+  PARTNERSHIP: "PARTNERSHIP",
+  CORPORATION: "CORPORATION",
+  COOPERATIVE: "COOPERATIVE",
+} as const;
+
 // Field configuration for the editable form
 export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
   // Business Information
@@ -46,6 +56,7 @@ export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
     required: true,
     placeholder: "ABC Services Corp.",
     section: "business",
+    // Shown for all business types
   },
   {
     key: "business_type",
@@ -53,6 +64,7 @@ export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
     required: false,
     placeholder: "Corporation / Sole Proprietor / Partnership",
     section: "business",
+    // Shown for all - read-only display of selected type
   },
   {
     key: "business_address",
@@ -60,20 +72,42 @@ export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
     required: false,
     placeholder: "123 Business St., Makati City",
     section: "business",
-  },
-  {
-    key: "permit_number",
-    label: "Business Permit Number",
-    required: false,
-    placeholder: "BP-2025-XXXXX",
-    section: "business",
+    // Shown for all business types
   },
   {
     key: "dti_number",
-    label: "DTI Registration Number",
+    label: "DTI Business Name Number",
     required: false,
-    placeholder: "DTI-XXXXX-XXXXX",
+    placeholder: "BN-7663018",
     section: "business",
+    // Only for Sole Proprietorship (DTI Registration)
+    applicableBusinessTypes: [BUSINESS_TYPES.SOLE_PROPRIETORSHIP],
+  },
+  {
+    key: "permit_number",
+    label: "Certificate/Permit ID",
+    required: false,
+    placeholder: "BPXW658418425073",
+    section: "business",
+    // Shown for all - but labeled based on context (DTI Cert ID or Mayor's Permit No.)
+  },
+  {
+    key: "permit_issue_date",
+    label: "Valid From",
+    required: false,
+    placeholder: "2025-01-06",
+    type: "date",
+    section: "business",
+    // Shown for all business types
+  },
+  {
+    key: "permit_expiry_date",
+    label: "Valid Until",
+    required: false,
+    placeholder: "2030-01-06",
+    type: "date",
+    section: "business",
+    // Shown for all business types
   },
   {
     key: "sec_number",
@@ -81,13 +115,8 @@ export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
     required: false,
     placeholder: "SEC-XXXXXXX",
     section: "business",
-  },
-  {
-    key: "tin",
-    label: "Tax Identification Number (TIN)",
-    required: false,
-    placeholder: "XXX-XXX-XXX-XXX",
-    section: "business",
+    // Only for Corporations and Partnerships
+    applicableBusinessTypes: [BUSINESS_TYPES.CORPORATION, BUSINESS_TYPES.PARTNERSHIP],
   },
   // Representative Information
   {


### PR DESCRIPTION
## Summary
Improves Agency KYC OCR extraction debugging and updates UI to show relevant fields based on business type.

## Backend Changes
- Add detailed debug logging with print statements to trace OCR text availability
- Log all file types and OCR text length for debugging
- Preview first 200 chars of OCR text in logs

## Frontend Changes
- Add \pplicableBusinessTypes\ property to field config
- DTI Business Name Number shown only for SOLE_PROPRIETORSHIP
- SEC Registration shown only for CORPORATION/PARTNERSHIP
- Added permit issue/expiry date fields
- Removed TIN field (not present on DTI certificates)
- Filter fields based on selected business type in UI

## Why?
- User reported autofill returns \has_extracted_data: false\
- UI was showing irrelevant fields for Sole Proprietorship (SEC, TIN)
- DTI certificate doesn't have same fields as Mayor's Permit

## Testing
Deploy and upload a DTI certificate - server logs will now show:
- All KYC file types found
- OCR text length per file
- OCR text preview
- Business type being saved