### PR TITLE
fix(kyc): improve face detection for ID photos and fix back ID

### DIFF
--- a/apps/backend/src/accounts/document_verification_service.py
+++ b/apps/backend/src/accounts/document_verification_service.py
@@ -227,7 +227,7 @@ FACE_REQUIRED_DOCUMENTS = [
 MIN_RESOLUTION = 400  # Minimum width or height in pixels (lowered from 640 for testing)
 MIN_FACE_SIZE_RATIO = 0.05  # Face must be at least 5% of image area
 MAX_BLUR_THRESHOLD = 100  # Laplacian variance threshold (lower = more blur)
-MIN_CONFIDENCE_FACE = 0.85  # Minimum confidence for face detection
+MIN_CONFIDENCE_FACE = 0.40  # Minimum confidence for face detection (lowered for ID photos with small/faded faces)
 
 
 class DocumentVerificationService:

--- a/apps/backend/src/agency/services.py
+++ b/apps/backend/src/agency/services.py
@@ -105,8 +105,8 @@ def upload_agency_kyc(payload, business_permit, rep_front, rep_back, address_pro
 		verification_service = DocumentVerificationService()
 		
 		# Define which documents require face detection
-		# REP_ID_FRONT and REP_ID_BACK require face detection (representative ID)
-		face_required_docs = ['REP_ID_FRONT', 'REP_ID_BACK']
+		# Only REP_ID_FRONT requires face detection - back of IDs don't have faces
+		face_required_docs = ['REP_ID_FRONT']
 		
 		# Define which documents require OCR keyword validation
 		# BUSINESS_PERMIT requires OCR to extract and validate business keywords


### PR DESCRIPTION
## Summary
Fixes face detection issues for KYC ID uploads.

## Changes

### 1. Lower Face Detection Threshold (40%)
- Changed \MIN_CONFIDENCE_FACE\ from 0.85 to 0.40
- Reason: ID photos have smaller faces and older documents may be faded
- File: \document_verification_service.py\

### 2. Remove Face Requirement for Back ID
- Removed \REP_ID_BACK\ from \ace_required_docs\
- Reason: Back of IDs don't have face photos
- File: \gency/services.py\

### 3. ID Type OCR Validation (Already Exists)
- Each ID type has specific keywords (e.g., Driver's License = LTO, LAND TRANSPORTATION)
- If OCR text doesn't match selected ID type, upload is rejected

## Affects
- Agency KYC (REP_ID_BACK)
- Regular KYC (BACKID already excluded from \FACE_REQUIRED_DOCUMENTS\)
- Mobile app uses same backend APIs