### PR TITLE
fix: Redis cache config for Upstash compatibility

### DIFF
--- a/apps/backend/src/iayos_project/settings.py
+++ b/apps/backend/src/iayos_project/settings.py
@@ -498,9 +498,6 @@ if REDIS_URL and REDIS_URL != "none":
         "default": {
             "BACKEND": "django.core.cache.backends.redis.RedisCache",
             "LOCATION": REDIS_URL,
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
             "KEY_PREFIX": "iayos",
             "TIMEOUT": 300,  # 5 minutes default cache timeout
         }


### PR DESCRIPTION
## Problem
Agency KYC validation was failing with error:
\\\
AbstractConnection.__init__() got an unexpected keyword argument 'CLIENT_CLASS'
\\\

This occurred during BN certificate and Rep Front ID validation uploads.

## Root Cause
The cache configuration had a mismatch between backend and options:
- **Backend**: \django.core.cache.backends.redis.RedisCache\ (Django's native Redis backend)
- **Options**: \CLIENT_CLASS: 'django_redis.client.DefaultClient'\ (option for separate django-redis library)

These two are incompatible. The native Django Redis backend doesn't accept the \CLIENT_CLASS\ parameter - that's only for the \django-redis\ third-party library which uses a different backend (\django_redis.cache.RedisCache\).

## Solution
Removed the incompatible \OPTIONS.CLIENT_CLASS\ parameter from the cache configuration.

Django's native Redis backend works perfectly with Upstash and other Redis-compatible services without needing the \CLIENT_CLASS\ option.

## Changes
- **File**: \pps/backend/src/iayos_project/settings.py\
- **Removed**: \OPTIONS.CLIENT_CLASS\ from CACHES configuration
- **Compatibility**: Works with Upstash cloud Redis service

## Testing
- Agency KYC validation endpoints should now work without errors
- Upload BN certificate and Rep Front ID to verify
- Cache operations use Django's native Redis backend