### PR TITLE
fix(face-api): stability improvements - keep-alive + memory cleanup

### DIFF
--- a/apps/face-api/requirements.txt
+++ b/apps/face-api/requirements.txt
@@ -10,6 +10,9 @@ python-multipart>=0.0.6
 Pillow>=10.0.0
 numpy>=1.24.0
 
+# System monitoring
+psutil>=5.9.0
+
 # Face detection dependencies
 # MediaPipe needs OpenCV, using headless to avoid X11 issues
 opencv-python-headless>=4.8.0


### PR DESCRIPTION
## Problem
Face-API service on Render shuts down after 1-2 image uploads. Two causes identified:

1. **Memory accumulation**: PIL images and numpy arrays not being explicitly cleaned up between requests
2. **Render free tier spin-down**: No activity = service stops after 15 minutes

## Solution

### 1. Memory Cleanup (Fixes crash after 1-2 uploads)
- Explicit \gc.collect()\ after each request
- Close PIL images with \image.close()\
- Delete numpy arrays with \del img_array\
- Use try/finally to ensure cleanup runs even on errors

### 2. Keep-Alive Background Task
- Logs activity every 5 minutes to show service is alive
- Runs periodic garbage collection
- Prevents Render from detecting 'inactivity'

### 3. Enhanced Health Check
- Added \memory_mb\ field showing current RAM usage
- Added \equests_served\ counter
- Helps diagnose memory issues in production

## Changes
- **File**: \pps/face-api/main.py\
  - Added \gc\, \syncio\, \psutil\ imports
  - Added \keep_alive()\ async background task
  - Added \equest_count\ global counter
  - Updated lifespan to start/stop keep-alive task
  - Added memory cleanup in \/detect\ and \/verify\ endpoints
  - Enhanced \/health\ with memory and request stats

- **File**: \pps/face-api/requirements.txt\
  - Added \psutil>=5.9.0\ for memory monitoring

## Testing
After deployment, check:
1. \GET /health\ - should show \memory_mb\ field
2. Upload multiple images - service should NOT shut down
3. Check logs for \🏓 Keep-alive\ messages every 5 min

## UptimeRobot Setup (Recommended)
Configure external monitoring for additional reliability:
- **URL**: \https://iayos-face-api.onrender.com/health\
- **Interval**: 5 minutes
- **Alert**: If status != 200