### PR TITLE
fix: Increase rate limits for production usage

### DIFF
--- a/apps/backend/src/iayos_project/rate_limiting.py
+++ b/apps/backend/src/iayos_project/rate_limiting.py
@@ -31,42 +31,43 @@ class RateLimitExceeded(Exception):
         super().__init__(f"Rate limit exceeded: {limit} requests per {window}s")
 
 
-# Rate limit configurations
+# Rate limit configurations (per IP address)
+# Production-ready limits - designed for real usage with multiple concurrent users
 RATE_LIMITS = {
-    # Authentication endpoints - strict limits
+    # Authentication endpoints - moderate limits (login attempts)
     "auth": {
-        "limit": 5,
-        "window": 60,  # 5 per minute
+        "limit": 20,
+        "window": 60,  # 20 per minute per IP
         "key_prefix": "rl:auth",
     },
-    # Password reset - very strict
+    # Password reset - strict to prevent abuse
     "password_reset": {
-        "limit": 3,
-        "window": 300,  # 3 per 5 minutes
+        "limit": 5,
+        "window": 300,  # 5 per 5 minutes per IP
         "key_prefix": "rl:pwd",
     },
-    # API write operations - moderate limits
+    # API write operations - generous limits
     "api_write": {
-        "limit": 30,
-        "window": 60,  # 30 per minute
+        "limit": 200,
+        "window": 60,  # 200 per minute per IP
         "key_prefix": "rl:write",
     },
-    # API read operations - lenient limits
+    # API read operations - very generous (dashboards poll many endpoints)
     "api_read": {
-        "limit": 100,
-        "window": 60,  # 100 per minute
+        "limit": 1000,
+        "window": 60,  # 1000 per minute per IP (~16 req/sec)
         "key_prefix": "rl:read",
     },
-    # File uploads - strict limits
+    # File uploads - moderate limits
     "upload": {
-        "limit": 10,
-        "window": 60,  # 10 per minute
+        "limit": 30,
+        "window": 60,  # 30 per minute per IP
         "key_prefix": "rl:upload",
     },
-    # Payment operations - very strict
+    # Payment operations - strict for security
     "payment": {
-        "limit": 5,
-        "window": 60,  # 5 per minute
+        "limit": 20,
+        "window": 60,  # 20 per minute per IP
         "key_prefix": "rl:payment",
     },
 }


### PR DESCRIPTION
## Problem
Production backend hitting rate limits during QA testing when multiple team members use admin dashboard simultaneously.

```
Rate limit exceeded: api_read for 49.145.225.186 (101/100) on /api/accounts/notifications/unread-count
Rate limit exceeded: api_read for 49.145.225.186 (101/100) on /api/adminpanel/kyc/all
Rate limit exceeded: api_read for 49.145.225.186 (101/100) on /api/adminpanel/withdrawals/statistics
```

**Root cause**: Admin dashboard polls multiple endpoints simultaneously, hitting 100 req/min limit quickly.

## Solution
Increased rate limits to production-ready values (all per IP address):

| Category | Before | After | Notes |
|----------|--------|-------|-------|
| api_read | 100/min | 1000/min | Dashboards poll many endpoints |
| api_write | 30/min | 200/min | Normal API operations |
| auth | 5/min | 20/min | Login attempts |
| upload | 10/min | 30/min | File uploads |
| payment | 5/min | 20/min | Payment operations |
| password_reset | 3/5min | 5/5min | Forgot password |

## Notes
- All limits are **per IP address** (already implemented via `get_client_ip()`)
- Auth/payment kept stricter for security
- 1000 req/min = ~16 requests/second per IP, plenty for dashboard usage