### PR TITLE
fix(backend): replace InsightFace with external Face API + fix OCR import

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -123,8 +123,8 @@ def extract_ocr_from_documents(request):
         if not business_permit:
             return Response({"error": "Business permit is required for OCR extraction"}, status=400)
         
-        # Run OCR extraction service
-        result = services.extract_ocr_for_autofill(
+        # Run OCR extraction service (imported directly from fast_upload_service)
+        result = extract_ocr_for_autofill(
             business_permit=business_permit,
             rep_id_front=rep_id_front,
             business_type=business_type


### PR DESCRIPTION
## Summary

This PR removes InsightFace/onnxruntime from the backend and replaces it with calls to the external Face API service (MediaPipe-based).

## Changes

### 1. face_detection_service.py - Complete Rewrite
- **Before**: Used InsightFace + onnxruntime (~180MB RAM) for face detection and verification
- **After**: Calls external Face API at `https://iayos-face-api.onrender.com`
- Auto-accepts all face validations (MediaPipe cannot match faces, only detect)
- Images are still stored in Supabase for manual review if needed

### 2. agency/api.py - Fixed Import Error
- **Before**: `services.extract_ocr_for_autofill(...)` - AttributeError (function not in services module)
- **After**: `extract_ocr_for_autofill(...)` - direct call to imported function

## Benefits
- ✅ Removes ~180MB RAM from backend (no more onnxruntime/InsightFace)
- ✅ Face detection still works via external service
- ✅ Faster cold starts (no InsightFace lazy loading)
- ✅ Fixes `AttributeError: module 'agency.services' has no attribute 'extract_ocr_for_autofill'`

## Face API Details
- **URL**: https://iayos-face-api.onrender.com
- **Endpoints**: `/health`, `/detect`, `/verify`
- **Model**: MediaPipe Face Detection (short-range)
- **RAM**: ~150MB (much lighter than InsightFace)

## Auto-Accept Logic
Since MediaPipe can only detect faces but NOT match/verify identity:
1. Check if face exists in ID document
2. Check if face exists in selfie
3. If both have faces → auto-accept
4. Images stored in Supabase for manual review if needed later

## Environment Variables (Optional)
- `FACE_API_URL` - defaults to `https://iayos-face-api.onrender.com`
- `FACE_API_TIMEOUT` - defaults to `30` seconds
- `MIN_FACE_CONFIDENCE` - defaults to `0.7`

## Testing
- [ ] Backend starts without errors
- [ ] KYC validation endpoints work
- [ ] Face detection returns results
- [ ] Auto-accept works as expected