### PR TITLE
fix: add document type validation to mobile KYC endpoint

### DIFF
--- a/apps/backend/src/accounts/api.py
+++ b/apps/backend/src/accounts/api.py
@@ -427,6 +427,9 @@ def validate_kyc_document(request):
     Checks resolution, blur, and face detection (for ID/selfie).
     Does NOT run OCR - that happens on final submission.
     
+    NOTE: This endpoint is for INDIVIDUAL/MOBILE KYC only.
+    Agency KYC uses /api/agency/kyc/validate-document with different document types.
+    
     Request: multipart/form-data
     - file: The document image file
     - document_type: Type of document (FRONTID, BACKID, CLEARANCE, SELFIE)
@@ -445,6 +448,12 @@ def validate_kyc_document(request):
         
         if not document_type:
             return {"valid": False, "error": "Document type not specified", "details": {}}
+        
+        # Validate document type - INDIVIDUAL/MOBILE KYC only
+        # Agency KYC documents (BUSINESS_PERMIT, REP_ID_FRONT, etc.) should use /api/agency/kyc/validate-document
+        valid_types = ['FRONTID', 'BACKID', 'CLEARANCE', 'SELFIE']
+        if document_type not in valid_types:
+            return {"valid": False, "error": f"Invalid document_type for individual KYC. Must be one of: {', '.join(valid_types)}", "details": {}}
         
         print(f"🔍 [VALIDATE] Document type: {document_type}, File: {file.name} ({file.size} bytes)")
         


### PR DESCRIPTION
## Summary
Adds explicit document type validation to the mobile KYC validation endpoint to ensure proper filtering between mobile and agency KYC flows.

## Changes
- Added validation for mobile KYC document types: FRONTID, BACKID, CLEARANCE, SELFIE
- Returns clear error message if invalid document type is provided
- Prevents agency document types (BUSINESS_PERMIT, REP_ID_FRONT, etc.) from being incorrectly accepted on mobile endpoint
- Matches the validation pattern already in place for agency KYC at \/api/agency/kyc/validate-document\

## Document Type Mapping
| Endpoint | Valid Document Types |
|----------|---------------------|
| Mobile KYC (\/api/accounts/kyc/validate-document\) | FRONTID, BACKID, CLEARANCE, SELFIE |
| Agency KYC (\/api/agency/kyc/validate-document\) | BUSINESS_PERMIT, REP_ID_FRONT, REP_ID_BACK, ADDRESS_PROOF, AUTH_LETTER |

## Testing
- Mobile app sends correct document types via \KYC_VALIDATE_DOCUMENT\ endpoint
- Agency web app sends correct document types via agency endpoint
- Each endpoint now rejects invalid document types with helpful error message