### PR TITLE
fix: agency KYC auto-verification cache retrieval and fallback

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -35,10 +35,11 @@ def upload_agency_kyc(request):
         business_type = request.POST.get("business_type", "SOLE_PROPRIETORSHIP")
         
         # Get file hashes from validation step (JSON string)
+        # Frontend sends 'file_hashes_json' field with JSON-encoded hashes
         import json
-        file_hashes_json = request.POST.get("file_hashes", "{}")
+        file_hashes_raw = request.POST.get("file_hashes_json", "{}")
         try:
-            file_hashes = json.loads(file_hashes_json)
+            file_hashes = json.loads(file_hashes_raw)
         except json.JSONDecodeError:
             file_hashes = {}
         

--- a/apps/backend/src/agency/fast_upload_service.py
+++ b/apps/backend/src/agency/fast_upload_service.py
@@ -344,7 +344,19 @@ def upload_agency_kyc_fast(payload, business_permit, rep_front, rep_back, addres
                 else:
                     print(f"   ⏳ [AUTO-APPROVAL] Thresholds not met, pending manual review")
         except Exception as e:
-            print(f"   ⚠️ [AUTO-APPROVAL] Check failed (will default to PENDING): {e}")
+            # AI service or auto-approval check failed - fallback to manual review
+            print(f"   ⚠️ [AUTO-APPROVAL] Check failed, falling back to manual review: {e}")
+            kyc_record.notes = f"Auto-approval check failed: {str(e)[:200]}. Requires manual review."
+            kyc_record.save()
+        
+        # If auto-approval didn't happen, ensure status is PENDING for manual review
+        if not auto_approved:
+            kyc_record.status = 'PENDING'
+            if not kyc_record.notes or kyc_record.notes == 'Re-submitted':
+                kyc_record.notes = 'Awaiting manual review by admin'
+            kyc_record.save()
+            final_status = "PENDING"
+            print(f"   📋 [MANUAL REVIEW] KYC set to PENDING for admin review")
         
         print(f"✅ [FAST UPLOAD] KYC uploaded successfully in ~5-10s (cached validation)")
         

--- a/apps/backend/src/agency/validation_cache.py
+++ b/apps/backend/src/agency/validation_cache.py
@@ -20,7 +20,7 @@ def cache_validation_result(
     file_hash: str,
     document_type: str,
     validation_result: Dict[str, Any],
-    timeout: int = 300  # 5 minutes
+    timeout: int = 600  # 10 minutes - allows time for user to fill forms
 ) -> None:
     """
     Cache validation result in Redis.


### PR DESCRIPTION
## Problem
Agency KYC auto-verification was not working - all submissions showed 'verification in progress' instead of auto-approving.

## Root Causes
1. **Field name mismatch**: Frontend sends \ile_hashes_json\ but backend was reading \ile_hashes\ - cached validation never retrieved
2. **Cache timeout too short**: 5 minutes not enough for users to complete forms - cache expired before submission
3. **Fallback behavior unclear**: When AI fails, status should explicitly be PENDING for manual review

## Changes
- Fix field name: backend now reads \ile_hashes_json\ correctly (matches frontend)
- Extend cache timeout: 5 → 10 minutes to allow form completion
- Explicit fallback: When auto-approval check fails (AI error or thresholds not met), explicitly set PENDING with descriptive notes
- No face comparison required (as requested - using same AI service for both mobile and agency)

## Testing
1. Upload agency KYC documents (business permit, rep ID, etc.)
2. Wait for validation to pass per step
3. Fill form and submit within 10 minutes
4. If \utoApproveKYC=true\ in PlatformSettings and confidence ≥ 0.7: should auto-approve
5. Otherwise: should show PENDING with note 'Awaiting manual review by admin'