### PR TITLE
fix: Agency KYC ID type cache bug + business type dropdown + OCR autofill refactor

### DIFF
--- a/apps/frontend_web/app/agency/kyc/page.tsx
+++ b/apps/frontend_web/app/agency/kyc/page.tsx
@@ -260,13 +260,14 @@ const AgencyKYCPage = () => {
 
     if (!result.valid) {
       // Get error message from AI rejection details or fallback
-      const errorMessage = result.error || 
+      const errorMessage =
+        result.error ||
         result.details?.ai_rejection_message ||
-        (result.details?.ai_rejection_reason === 'MISSING_REQUIRED_TEXT'
-          ? 'Could not verify business permit. Please ensure the document shows required text (Business, Permit, City/Municipality) clearly.'
-          : result.details?.ai_rejection_reason === 'IMAGE_TOO_BLURRY'
-          ? 'Image is too blurry. Please upload a clearer photo.'
-          : 'Document validation failed. Please try again with a clearer image.');
+        (result.details?.ai_rejection_reason === "MISSING_REQUIRED_TEXT"
+          ? "Could not verify business permit. Please ensure the document shows required text (Business, Permit, City/Municipality) clearly."
+          : result.details?.ai_rejection_reason === "IMAGE_TOO_BLURRY"
+            ? "Image is too blurry. Please upload a clearer photo."
+            : "Document validation failed. Please try again with a clearer image.");
       setPermitValidationError(errorMessage);
       showToast({
         type: "error",
@@ -319,15 +320,16 @@ const AgencyKYCPage = () => {
 
     if (!result.valid) {
       // Get error message from AI rejection details or fallback
-      const errorMessage = result.error || 
+      const errorMessage =
+        result.error ||
         result.details?.ai_rejection_message ||
-        (result.details?.ai_rejection_reason === 'MISSING_REQUIRED_TEXT' 
-          ? 'Could not verify document authenticity. Please ensure the document shows required text clearly.'
-          : result.details?.ai_rejection_reason === 'NO_FACE_DETECTED'
-          ? 'No face detected in ID document. Please upload a clear photo of your ID showing your face.'
-          : result.details?.ai_rejection_reason === 'IMAGE_TOO_BLURRY'
-          ? 'Image is too blurry. Please upload a clearer photo.'
-          : 'Validation failed. Please try again with a clearer image.');
+        (result.details?.ai_rejection_reason === "MISSING_REQUIRED_TEXT"
+          ? "Could not verify document authenticity. Please ensure the document shows required text clearly."
+          : result.details?.ai_rejection_reason === "NO_FACE_DETECTED"
+            ? "No face detected in ID document. Please upload a clear photo of your ID showing your face."
+            : result.details?.ai_rejection_reason === "IMAGE_TOO_BLURRY"
+              ? "Image is too blurry. Please upload a clearer photo."
+              : "Validation failed. Please try again with a clearer image.");
       setRepFrontValidationError(errorMessage);
       showToast({
         type: "error",
@@ -389,13 +391,14 @@ const AgencyKYCPage = () => {
 
     if (!result.valid) {
       // Get error message from AI rejection details or fallback
-      const errorMessage = result.error || 
+      const errorMessage =
+        result.error ||
         result.details?.ai_rejection_message ||
-        (result.details?.ai_rejection_reason === 'IMAGE_TOO_BLURRY'
-          ? 'Image is too blurry. Please upload a clearer photo.'
-          : result.details?.ai_rejection_reason === 'RESOLUTION_TOO_LOW'
-          ? 'Image resolution is too low. Please upload a higher quality image.'
-          : 'ID back validation failed. Please try again with a clearer image.');
+        (result.details?.ai_rejection_reason === "IMAGE_TOO_BLURRY"
+          ? "Image is too blurry. Please upload a clearer photo."
+          : result.details?.ai_rejection_reason === "RESOLUTION_TOO_LOW"
+            ? "Image resolution is too low. Please upload a higher quality image."
+            : "ID back validation failed. Please try again with a clearer image.");
       setRepBackValidationError(errorMessage);
       showToast({
         type: "error",
@@ -485,8 +488,10 @@ const AgencyKYCPage = () => {
       dti_number: fields.dti_number || prev.dti_number || "",
       sec_number: fields.sec_number || prev.sec_number || "",
       tin: fields.tin || prev.tin || "",
-      permit_issue_date: fields.permit_issue_date || prev.permit_issue_date || "",
-      permit_expiry_date: fields.permit_expiry_date || prev.permit_expiry_date || "",
+      permit_issue_date:
+        fields.permit_issue_date || prev.permit_issue_date || "",
+      permit_expiry_date:
+        fields.permit_expiry_date || prev.permit_expiry_date || "",
     }));
 
     if (fields.business_name) setBusinessName(fields.business_name);
@@ -571,14 +576,11 @@ const AgencyKYCPage = () => {
 
       console.log("📝 Running representative ID OCR autofill...");
 
-      const response = await fetch(
-        `${API_BASE}/api/agency/kyc/autofill-id`,
-        {
-          method: "POST",
-          credentials: "include",
-          body: formData,
-        },
-      );
+      const response = await fetch(`${API_BASE}/api/agency/kyc/autofill-id`, {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
 
       if (!response.ok) {
         throw new Error("ID autofill failed");
@@ -701,12 +703,14 @@ const AgencyKYCPage = () => {
 
       // Check if auto-approved
       const wasAutoApproved = responseData?.auto_approved === true;
-      
+
       showToast({
         type: wasAutoApproved ? "success" : "success",
-        title: wasAutoApproved 
-          ? "Agency Verified! ✅" 
-          : (agencyKycStatus?.toUpperCase() === "REJECTED" ? "Resubmitted" : "Submitted"),
+        title: wasAutoApproved
+          ? "Agency Verified! ✅"
+          : agencyKycStatus?.toUpperCase() === "REJECTED"
+            ? "Resubmitted"
+            : "Submitted",
         message: wasAutoApproved
           ? "Your agency has been automatically verified!"
           : "Documents uploaded successfully. Verification in progress.",
@@ -1329,8 +1333,8 @@ const AgencyKYCPage = () => {
           Review Business Information
         </h1>
         <p className="text-gray-600 mb-6 text-center text-sm">
-          We&apos;ve extracted business information from your registration certificate.
-          Please review and correct any errors.
+          We&apos;ve extracted business information from your registration
+          certificate. Please review and correct any errors.
         </p>
 
         {/* OCR Extraction Success Notice */}
@@ -1353,8 +1357,12 @@ const AgencyKYCPage = () => {
                   ✨ Business Data Extracted
                 </h3>
                 <p className="text-xs text-green-800">
-                  Data from your {businessType === "SOLE_PROPRIETORSHIP" ? "DTI Certificate" : "SEC Registration"} has been autofilled.
-                  Please verify accuracy and edit if needed.
+                  Data from your{" "}
+                  {businessType === "SOLE_PROPRIETORSHIP"
+                    ? "DTI Certificate"
+                    : "SEC Registration"}{" "}
+                  has been autofilled. Please verify accuracy and edit if
+                  needed.
                 </p>
               </div>
             </div>
@@ -1371,8 +1379,18 @@ const AgencyKYCPage = () => {
             {/* Business Information Section */}
             <div className="mb-6">
               <h2 className="text-lg font-semibold text-gray-900 mb-3 pb-2 border-b flex items-center gap-2">
-                <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+                <svg
+                  className="w-5 h-5 text-blue-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                  />
                 </svg>
                 Business Information
               </h2>
@@ -1459,8 +1477,18 @@ const AgencyKYCPage = () => {
                 className="px-6 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center gap-2"
               >
                 Next: Representative ID
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
                 </svg>
               </button>
             </div>
@@ -1478,8 +1506,8 @@ const AgencyKYCPage = () => {
           Review Representative ID
         </h1>
         <p className="text-gray-600 mb-6 text-center text-sm">
-          We&apos;ve extracted information from your representative&apos;s ID document.
-          Please review and correct any errors before submitting.
+          We&apos;ve extracted information from your representative&apos;s ID
+          document. Please review and correct any errors before submitting.
         </p>
 
         {/* OCR Extraction Success Notice */}
@@ -1501,8 +1529,9 @@ const AgencyKYCPage = () => {
                 🪪 ID Data Extracted
               </h3>
               <p className="text-xs text-purple-800">
-                Information from the representative&apos;s {ID_TYPES.find(t => t.value === repIdType)?.label || "ID"} has been autofilled.
-                Please verify accuracy and edit if needed.
+                Information from the representative&apos;s{" "}
+                {ID_TYPES.find((t) => t.value === repIdType)?.label || "ID"} has
+                been autofilled. Please verify accuracy and edit if needed.
               </p>
             </div>
           </div>
@@ -1518,8 +1547,18 @@ const AgencyKYCPage = () => {
             {/* Representative Information Section */}
             <div className="mb-6">
               <h2 className="text-lg font-semibold text-gray-900 mb-3 pb-2 border-b flex items-center gap-2">
-                <svg className="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2" />
+                <svg
+                  className="w-5 h-5 text-purple-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"
+                  />
                 </svg>
                 Authorized Representative
               </h2>
@@ -1537,7 +1576,11 @@ const AgencyKYCPage = () => {
                     <div className="relative">
                       {field.type === "select" ? (
                         <select
-                          value={field.key === "rep_id_type" ? (ocrFields[field.key] || repIdType) : (ocrFields[field.key] || businessType)}
+                          value={
+                            field.key === "rep_id_type"
+                              ? ocrFields[field.key] || repIdType
+                              : ocrFields[field.key] || businessType
+                          }
                           onChange={(e) => {
                             handleOcrFieldChange(field.key, e.target.value);
                             if (field.key === "rep_id_type") {
@@ -1667,8 +1710,8 @@ const AgencyKYCPage = () => {
           Review Extracted Information
         </h1>
         <p className="text-gray-600 mb-6 text-center text-sm">
-          We&apos;ve extracted the following information from your documents. Please
-          review and correct any errors before submitting.
+          We&apos;ve extracted the following information from your documents.
+          Please review and correct any errors before submitting.
         </p>
 
         {/* OCR Extraction Success Notice */}
@@ -1782,7 +1825,11 @@ const AgencyKYCPage = () => {
                     <div className="relative">
                       {field.type === "select" ? (
                         <select
-                          value={field.key === "rep_id_type" ? (ocrFields[field.key] || repIdType) : (ocrFields[field.key] || "")}
+                          value={
+                            field.key === "rep_id_type"
+                              ? ocrFields[field.key] || repIdType
+                              : ocrFields[field.key] || ""
+                          }
                           onChange={(e) => {
                             handleOcrFieldChange(field.key, e.target.value);
                             if (field.key === "rep_id_type") {

--- a/apps/frontend_web/lib/hooks/useAgencyKYCAutofill.ts
+++ b/apps/frontend_web/lib/hooks/useAgencyKYCAutofill.ts
@@ -130,7 +130,10 @@ export const AGENCY_KYC_FIELD_CONFIG: AgencyKYCField[] = [
     placeholder: "SEC-XXXXXXX",
     section: "business",
     // Only for Corporations and Partnerships
-    applicableBusinessTypes: [BUSINESS_TYPES.CORPORATION, BUSINESS_TYPES.PARTNERSHIP],
+    applicableBusinessTypes: [
+      BUSINESS_TYPES.CORPORATION,
+      BUSINESS_TYPES.PARTNERSHIP,
+    ],
   },
   // Representative Information
   {


### PR DESCRIPTION
## Changes

### 1. ID Type Cache Fix
- Added handleRepIdTypeChange() that clears rep ID files, previews, validation errors, and file hashes when ID type changes
- Prevents cache bug where validate-document checks against previously selected ID type
- Shows toast notification to inform user to re-upload documents
- Updated all 3 ID type dropdown onChange handlers

### 2. Business Type Dropdown
- Changed usiness_type from text input to select dropdown
- Options: Sole Proprietorship (DTI), Partnership (SEC), Corporation (SEC), Cooperative (CDA)
- Added BUSINESS_TYPE_OPTIONS export to useAgencyKYCAutofill hook

### 3. OCR Autofill Refactor
- Replaced deprecated xtract-ocr endpoint with new separate autofill endpoints
- Step 2 → Step 3: Navigate, then useEffect triggers utofill-business
- Step 3 → Step 4: Navigate, then useEffect triggers utofill-id
- Added loading states and toast notifications for each autofill
- Better UX: forms load instantly, then populate with OCR data asynchronously

## Testing
- ✅ TypeScript: 0 errors
- ✅ Backend endpoints operational
- ⏳ Manual testing required

## Files Modified
- pps/frontend_web/app/agency/kyc/page.tsx
- pps/frontend_web/lib/hooks/useAgencyKYCAutofill.ts

## Commits
1. 965413 - ID type cache fix + business type dropdown
2. 6b75a04 - Replace deprecated extract-ocr endpoint
3. 348e2e1 - Run OCR autofill on step load
4. 8b13177 - Prettier formatting