### PR TITLE
feat: add real agency stats and revenue trends endpoint

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -743,6 +743,30 @@ def get_profile(request):
         return Response({"error": "Internal server error"}, status=500)
 
 
+@router.get("/analytics/revenue-trends", auth=cookie_auth)
+def get_revenue_trends(request, weeks: int = 12):
+    """
+    Get weekly revenue and job completion trends for analytics charts.
+    
+    Query params:
+        weeks: Number of weeks to fetch (default: 12, max: 52)
+    
+    Returns:
+        List of weekly data points with date, revenue, and jobs completed
+    """
+    try:
+        account_id = request.auth.accountID
+        # Cap weeks at 52 (1 year)
+        weeks = min(weeks, 52)
+        trends = services.get_revenue_trends(account_id, weeks)
+        return {"success": True, "trends": trends, "weeks": weeks}
+    except ValueError as e:
+        return Response({"error": str(e)}, status=400)
+    except Exception as e:
+        print(f"Error fetching revenue trends: {str(e)}")
+        return Response({"error": "Internal server error"}, status=500)
+
+
 @router.post("/profile/update", auth=cookie_auth)
 def update_profile(request):
     """Update agency profile information."""

--- a/apps/frontend_web/app/agency/analytics/page.tsx
+++ b/apps/frontend_web/app/agency/analytics/page.tsx
@@ -33,10 +33,7 @@ import {
 import { format, subMonths } from "date-fns";
 
 export default function AnalyticsPage() {
-  const [dateRange, setDateRange] = useState({
-    start: subMonths(new Date(), 3),
-    end: new Date(),
-  });
+  const [weeksRange, setWeeksRange] = useState(12); // Default 12 weeks (3 months)
   const [leaderboardSort, setLeaderboardSort] = useState<
     "rating" | "jobs" | "earnings"
   >("rating");
@@ -47,8 +44,7 @@ export default function AnalyticsPage() {
     20
   );
   const { data: revenueTrends, isLoading: trendsLoading } = useRevenueTrends(
-    dateRange.start,
-    dateRange.end
+    weeksRange
   );
 
   if (statsLoading || leaderboardLoading || trendsLoading) {

--- a/apps/frontend_web/lib/hooks/useAnalytics.ts
+++ b/apps/frontend_web/lib/hooks/useAnalytics.ts
@@ -103,47 +103,30 @@ export function useLeaderboard(
 }
 
 /**
- * Fetch revenue trends (mock data for now - can be replaced with real API)
+ * Fetch revenue trends from the backend API
  */
-export function useRevenueTrends(startDate: Date, endDate: Date) {
+export function useRevenueTrends(weeks: number = 12) {
   return useQuery<RevenueTrendData[]>({
-    queryKey: [
-      "agency",
-      "revenue-trends",
-      startDate.toISOString(),
-      endDate.toISOString(),
-    ],
+    queryKey: ["agency", "revenue-trends", weeks],
     queryFn: async () => {
-      // For now, generate mock data
-      // In production, this would call: GET /api/agency/analytics/revenue-trends?start=X&end=Y
-      return generateMockRevenueTrends(startDate, endDate);
+      const response = await fetch(
+        `${API_BASE}/api/agency/analytics/revenue-trends?weeks=${weeks}`,
+        {
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch revenue trends");
+      }
+
+      const data = await response.json();
+      return data.trends || [];
     },
     refetchOnWindowFocus: false,
     staleTime: 10 * 60 * 1000, // 10 minutes
   });
-}
-
-/**
- * Generate mock revenue trends data
- * TODO: Replace with real API endpoint when analytics backend is implemented
- */
-function generateMockRevenueTrends(
-  startDate: Date,
-  endDate: Date,
-): RevenueTrendData[] {
-  const data: RevenueTrendData[] = [];
-  const currentDate = new Date(startDate);
-
-  while (currentDate <= endDate) {
-    data.push({
-      date: currentDate.toISOString().split("T")[0],
-      revenue: Math.floor(Math.random() * 10000) + 5000,
-      jobs: Math.floor(Math.random() * 20) + 5,
-    });
-    currentDate.setDate(currentDate.getDate() + 7); // Weekly intervals
-  }
-
-  return data;
 }
 
 /**


### PR DESCRIPTION
## Summary
Replaces placeholder zeros in agency profile stats with real job data, and adds a new revenue trends endpoint for analytics charts.

## Backend Changes
- services.py: Modified get_agency_profile() to query real job statistics
- services.py: Added get_revenue_trends() function for weekly revenue aggregation
- api.py: Added GET /api/agency/analytics/revenue-trends endpoint

## Frontend Changes
- useAnalytics.ts: Updated useRevenueTrends hook to call real API instead of mock data
- analytics/page.tsx: Changed from date range to weeks parameter

## Testing
- Endpoints return 401 Unauthorized when called without auth (verified)
- Frontend hooks properly typed and error-free