### PR TITLE
fix: agency KYC auto-verify cache key mismatch

### DIFF
--- a/apps/backend/src/adminpanel/migrations/0012_enable_auto_approve_kyc.py
+++ b/apps/backend/src/adminpanel/migrations/0012_enable_auto_approve_kyc.py
@@ -1,0 +1,28 @@
+# Manual migration to enable auto-approve KYC by default
+
+from django.db import migrations
+
+
+def enable_auto_approve(apps, schema_editor):
+    """Set autoApproveKYC to True for all PlatformSettings records."""
+    PlatformSettings = apps.get_model('adminpanel', 'PlatformSettings')
+    PlatformSettings.objects.all().update(autoApproveKYC=True)
+    print("✅ Enabled autoApproveKYC for all PlatformSettings records")
+
+
+def disable_auto_approve(apps, schema_editor):
+    """Reverse migration - set autoApproveKYC back to False."""
+    PlatformSettings = apps.get_model('adminpanel', 'PlatformSettings')
+    PlatformSettings.objects.all().update(autoApproveKYC=False)
+    print("⬅️ Disabled autoApproveKYC for all PlatformSettings records")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('adminpanel', '0011_kyc_auto_approval_thresholds'),
+    ]
+
+    operations = [
+        migrations.RunPython(enable_auto_approve, reverse_code=disable_auto_approve),
+    ]

--- a/apps/backend/src/agency/fast_upload_service.py
+++ b/apps/backend/src/agency/fast_upload_service.py
@@ -90,6 +90,7 @@ def upload_agency_kyc_fast(payload, business_permit, rep_front, rep_back, addres
 
         uploaded_files = []
         file_hashes = getattr(payload, 'file_hashes', {})
+        rep_id_type = getattr(payload, 'rep_id_type', None)
         
         # ============================================
         # PARALLEL FILE UPLOAD TO SUPABASE
@@ -119,18 +120,24 @@ def upload_agency_kyc_fast(payload, business_permit, rep_front, rep_back, addres
                 # Get cached validation result from Redis
                 from .validation_cache import get_cached_validation, generate_file_hash
                 
+                # Construct cache key matching validation step's composite key pattern
+                # For REP_ID_FRONT/REP_ID_BACK, use "REP_ID_FRONT:PHILSYS_ID" format
+                cache_key = f"{key}:{rep_id_type}" if rep_id_type and key in ['REP_ID_FRONT', 'REP_ID_BACK'] else key
+                
                 file_hash = file_hashes.get(key)
                 cached_validation = None
                 
                 if file_hash:
-                    cached_validation = get_cached_validation(file_hash, key)
+                    cached_validation = get_cached_validation(file_hash, cache_key)
+                    print(f"🔍 [CACHE LOOKUP] {key} with cache_key='{cache_key}', hash={file_hash[:8]}... → {'HIT' if cached_validation else 'MISS'}")
                 else:
                     # Fallback: generate hash from file data if not provided
                     file.seek(0)
                     file_data = file.read()
                     file.seek(0)
                     file_hash = generate_file_hash(file_data)
-                    cached_validation = get_cached_validation(file_hash, key)
+                    cached_validation = get_cached_validation(file_hash, cache_key)
+                    print(f"🔍 [CACHE LOOKUP] {key} with cache_key='{cache_key}', hash={file_hash[:8]}... (generated) → {'HIT' if cached_validation else 'MISS'}")
                 
                 # Extract validation results from cache (or use defaults)
                 ai_status = 'PENDING'


### PR DESCRIPTION
## Issue
Auto-verify was not triggering after KYC upload even when all AI validations passed.

## Root Cause
Cache key mismatch between validation and upload steps:
- Validation stores: REP_ID_FRONT:PHILSYS_ID (composite key)
- Upload looks for: REP_ID_FRONT (simple key)
- Result: Cache MISS → defaults to PENDING status → auto-approve conditions fail

## Changes
1. fast_upload_service.py: Use composite cache key for REP_ID_FRONT/REP_ID_BACK matching validation pattern
2. fast_upload_service.py: Extract rep_id_type from payload to construct correct cache key
3. fast_upload_service.py: Add debug logging for cache hit/miss troubleshooting
4. Migration 0012: Enable autoApproveKYC=True by default in PlatformSettings

## Impact
- Cache lookups now match validation step pattern (HIT instead of MISS)
- Auto-approval triggers when all validations pass with sufficient confidence
- Debug logs show exact cache keys for easier troubleshooting

## Testing
- Cache lookup now uses composite key for rep ID documents
- Migration sets autoApproveKYC=True for all PlatformSettings records