### PR TITLE
fix: Agency KYC loading states and OCR business name extraction

### DIFF
--- a/apps/backend/src/agency/kyc_extraction_parser.py
+++ b/apps/backend/src/agency/kyc_extraction_parser.py
@@ -227,6 +227,7 @@ class AgencyKYCExtractionParser:
                 "REPUBLIC",
                 "PHILIPPINES",
                 "IS A BUSINESS NAME REGISTERED",
+                "BARANGAY",
             ]
             for line in lines[:12]:
                 line = line.strip()

--- a/apps/frontend_web/app/agency/kyc/page.tsx
+++ b/apps/frontend_web/app/agency/kyc/page.tsx
@@ -1537,10 +1537,10 @@ const AgencyKYCPage = () => {
           </div>
         </div>
 
-        {ocrLoading ? (
+        {isExtractingOCR ? (
           <div className="flex flex-col items-center justify-center py-12">
             <div className="w-10 h-10 border-4 border-purple-600 border-t-transparent rounded-full animate-spin mb-4"></div>
-            <p className="text-gray-600">Loading extracted data...</p>
+            <p className="text-gray-600">Extracting ID data from document...</p>
           </div>
         ) : (
           <>


### PR DESCRIPTION
## Section 2: Fix Loading States During OCR Extraction

**Problem**: Loading spinners never displayed during business/ID autofill OCR extraction, making the UI appear frozen for 2-5 seconds.

**Root Cause**: 
- fetchBusinessAutofill() and fetchRepAutofill() set isExtractingOCR state
- UI checked ocrLoading state from useAgencyKYCAutofill hook
- Hook tracks GET endpoint (stored data), not POST autofill calls (live OCR)

**Solution**:
- Changed loading checks from ocrLoading to isExtractingOCR in Step 3 and Step 4
- Updated loading messages for clarity

## Section 3: Fix Business Name OCR Capturing BARANGAY

**Problem**: Business name OCR sometimes extracted (BARANGAY) instead of actual business name from DTI certificates.

**Root Cause**: 
- Primary regex works correctly and stops at parenthesis
- Fallback logic scans first 12 uppercase lines
- excluded_phrases list missing BARANGAY - could capture location text

**Solution**:
- Added BARANGAY to excluded_phrases list in kyc_extraction_parser.py
- Prevents fallback from capturing location markers as business name

## Testing
- Test Step 3 business document autofill - verify loading spinner shows
- Test Step 4 ID autofill - verify loading spinner shows  
- Test DTI certificate with BARANGAY text - verify business name extracted correctly
- Verify auto-approval still working from PR #118

Related to PR #118 (auto-verify cache key fix)