### PR TITLE
fix: add missing Switch component for Vercel build

### DIFF
--- a/apps/frontend_web/components/ui/switch.tsx
+++ b/apps/frontend_web/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-blue-600 data-[state=unchecked]:bg-gray-200 dark:focus-visible:ring-offset-gray-950 dark:data-[state=checked]:bg-blue-500 dark:data-[state=unchecked]:bg-gray-800",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/apps/frontend_web/package.json
+++ b/apps/frontend_web/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.13",
     "@react-email/components": "^0.5.5",
     "@react-email/render": "^1.3.1",


### PR DESCRIPTION
Fixes Vercel build error: \Module not found: Can't resolve '@/components/ui/switch'\

## Changes
- Created \components/ui/switch.tsx\ using Radix UI primitives (standard shadcn/ui pattern)
- Added \@radix-ui/react-switch ^1.1.3\ to package.json dependencies

## Root Cause
The agency settings page (\/agency/settings\) imports Switch component but it was never created.