### PR TITLE
feat: Add DATABASE_TEST_URL support for Maestro E2E tests

### DIFF
--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -53,6 +53,10 @@ env:
   API_URL: "https://api.iayos.online"
   # App package name (must match app.json and build.gradle)
   APP_ID: "com.devante.iayos"
+  # Test database connection (set in GitHub Secrets)
+  # This tells the backend to use the test database instead of production
+  # Database name MUST contain "test" for cleanup endpoint to work
+  DATABASE_TEST_URL: ${{ secrets.DATABASE_TEST_URL }}
 
 jobs:
   maestro-tests:


### PR DESCRIPTION
## Changes

### Backend (settings.py)
- Added DATABASE_TEST_URL environment variable as highest priority database configuration
- Priority order: DATABASE_TEST_URL > DATABASE_URL_LOCAL > DATABASE_URL
- Test database uses SSL (cloud database like Neon)
- Added visual indicators: Test DB / Local DB / Production DB
- Console prints which database is being used on startup

### Maestro Workflow
- Added DATABASE_TEST_URL to environment variables from GitHub Secrets
- Backend will use test database when this secret is set
- Added comments explaining usage and security requirements

## How It Works

Priority Hierarchy:
1. DATABASE_TEST_URL (E2E tests) - Use test/staging database
2. DATABASE_URL_LOCAL (Local dev) - Use local PostgreSQL
3. DATABASE_URL (Production) - Use production database (default)

Security:
- Test cleanup endpoint only works if database name contains test
- Safe to set DATABASE_TEST_URL - will not affect production data

## Setup Instructions

1. Create Test Database in Neon (name must contain test)
2. Run migrations on test database
3. Create test users (worker.test@iayos.com, client.test@iayos.com)
4. Set DATABASE_TEST_URL in Render environment variables
5. Set DATABASE_TEST_URL in GitHub repository secrets

Ready to merge!