### PR TITLE
fix(mobile): restore missing function declaration in ErrorState

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/components/ui/ErrorState.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/ui/ErrorState.tsx
@@ -32,6 +32,7 @@ interface ErrorStateProps {
   style?: ViewStyle;
 }
 
+export default function ErrorState({
   title = 'Something went wrong',
   message,
   onRetry,


### PR DESCRIPTION
## Summary
Fix syntax error in ErrorState.tsx that was blocking mobile app builds.

## Issue
During EAS build, the bundler failed with:
`
SyntaxError: Unexpected token (40:0)
> 40 | }: ErrorStateProps) {
`

## Root Cause
The previous merge accidentally removed the function declaration line:
xport default function ErrorState({

## Fix
Restored the missing function declaration before the parameter destructuring.

## Testing
- TypeScript compilation passes with 0 errors
- Syntax is now valid