### PR TITLE
fix(mobile): Android crash on startup v1.7.2

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "iayos_mobile",
     "slug": "iayos_mobile",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "projectId": "9aefe802-18a0-41ab-9d65-c112999529f8",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/apps/frontend_mobile/iayos_mobile/app/(tabs)/_layout.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/(tabs)/_layout.tsx
@@ -8,19 +8,6 @@ import { Colors } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuth } from "@/context/AuthContext";
 import { KYCBanner } from "@/components/KYCBanner";
-// Debug imports at runtime to detect undefined exports
-try {
-  // eslint-disable-next-line no-console
-  console.log("[TabsLayout] Imports:", {
-    Tabs: typeof Tabs !== "undefined" ? "defined" : "undefined",
-    HapticTab: typeof HapticTab !== "undefined" ? "defined" : "undefined",
-    IconSymbol: typeof IconSymbol !== "undefined" ? "defined" : "undefined",
-    Colors: typeof Colors !== "undefined" ? "defined" : "undefined",
-    useColorScheme:
-      typeof useColorScheme !== "undefined" ? "defined" : "undefined",
-    useAuth: typeof useAuth !== "undefined" ? "defined" : "undefined",
-  });
-} catch (e) {}
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();

--- a/apps/frontend_mobile/iayos_mobile/components/ui/icon-symbol.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/ui/icon-symbol.tsx
@@ -5,20 +5,27 @@ import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
 import { ComponentProps } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
-type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
-type IconSymbolName = keyof typeof MAPPING;
+type IconMapping = Record<string, ComponentProps<typeof MaterialIcons>['name']>;
 
 /**
  * Add your SF Symbols to Material Icons mappings here.
  * - see Material Icons in the [Icons Directory](https://icons.expo.fyi).
  * - see SF Symbols in the [SF Symbols](https://developer.apple.com/sf-symbols/) app.
  */
-const MAPPING = {
+const MAPPING: IconMapping = {
+  // Tab bar navigation icons
   'house.fill': 'home',
+  'briefcase.fill': 'work',
+  'message.fill': 'message',
+  'person.fill': 'person',
+  // Other icons
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
-} as IconMapping;
+};
+
+// Allow any SF Symbol name - fallback to 'help' if not mapped
+type IconSymbolName = string;
 
 /**
  * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.
@@ -37,5 +44,6 @@ export function IconSymbol({
   style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
-  return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;
+  const materialName = MAPPING[name] || 'help'; // Fallback to 'help' icon if not mapped
+  return <MaterialIcons color={color} size={size} name={materialName} style={style} />;
 }

--- a/apps/frontend_mobile/iayos_mobile/lib/services/notifications.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/services/notifications.ts
@@ -1,21 +1,11 @@
 // Push Notifications Service
 // Handle local and push notifications for chat messages
+// NOTE: Notification handler is configured in notificationService.ts to avoid duplicate handlers
 
 import * as Notifications from "expo-notifications";
 import * as Device from "expo-device";
 import { Platform } from "react-native";
 import Constants from "expo-constants";
-
-// Configure notification behavior
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: true,
-    shouldShowBanner: true,
-    shouldShowList: true,
-  }),
-});
 
 export type NotificationData = {
   conversationId: number;

--- a/apps/frontend_mobile/iayos_mobile/package.json
+++ b/apps/frontend_mobile/iayos_mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iayos_mobile",
   "main": "expo-router/entry",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary
Fixes critical Android crash on app startup in v1.7.1.

## Root Cause
The IconSymbol component was missing SF Symbol to MaterialIcons mappings for 3 tab bar icons. On Android, this caused the tab bar to render with undefined icon names, crashing the app.

## Fixes
1. **Icon mappings** - Added missing mappings:
   - briefcase.fill -> work (Jobs tab)
   - message.fill -> message (Messages tab)
   - person.fill -> person (Profile tab)

2. **Fallback icon** - Added fallback to 'help' icon for any unmapped SF Symbols to prevent future crashes

3. **Duplicate notification handler** - Removed duplicate Notifications.setNotificationHandler() call from notifications.ts (kept in notificationService.ts)

4. **Debug logging** - Removed console.log debug code from tabs layout

## Version
1.7.1 -> 1.7.2

## Testing
Build Android APK and verify app launches without crash