### PR TITLE
fix: Handle 502/503/504 non-JSON errors in KYC validate

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app/settings/change-password.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/settings/change-password.tsx
@@ -69,7 +69,12 @@ export default function ChangePasswordScreen() {
       );
 
       if (!response.ok) {
-        const error = await response.json();
+        // Check content-type before parsing JSON (handle 502/503/504 HTML responses)
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          throw new Error(`Server error (${response.status}). Please try again later.`);
+        }
+        const error = await response.json().catch(() => ({ detail: 'Unknown error' }));
         throw new Error(error.detail || 'Failed to change password');
       }
 


### PR DESCRIPTION
## Problem
KYC document validation was throwing uncaught errors when receiving HTML responses from gateway errors (502, 503, 504).

**Error seen:**
\\\
ERROR [KYC Validate] Non-JSON response (502): text/html; charset=UTF-8
\\\

## Solution
1. **KYC upload.tsx**: Move content-type check BEFORE status checks in \alidateDocument\
   - Check for non-JSON responses first (catches 502, 503, 504)
   - Add specific user-friendly messages for each gateway error
   - Wrap successful JSON parsing in try-catch for edge cases

2. **change-password.tsx**: Add content-type check before parsing error JSON
   - Prevent JSON parse errors on HTML error pages
   - Use \.catch()\ fallback for safer parsing

## Files Changed
- \pps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx\
- \pps/frontend_mobile/iayos_mobile/app/settings/change-password.tsx\

## Testing
- [x] Graceful error handling for 502 Bad Gateway
- [x] Graceful error handling for 503 Service Unavailable  
- [x] Graceful error handling for 504 Gateway Timeout
- [x] Normal JSON responses still work correctly