### PR TITLE
fix: Increase OCR timeout from 90s to 5 minutes

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -442,7 +442,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 // HTTP Request helper with credentials
 // API request helper with built-in timeout using AbortController
 export const DEFAULT_REQUEST_TIMEOUT = 15000; // 15 seconds
-export const OCR_TIMEOUT = 90000; // 90 seconds (1.5 min) for OCR extraction operations
+export const OCR_TIMEOUT = 300000; // 5 minutes for OCR extraction operations (Tesseract can take 2-4 min)
 
 export const apiRequest = async (
   url: string,

--- a/apps/frontend_mobile/iayos_mobile/lib/hooks/useKYCAutofill.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/hooks/useKYCAutofill.ts
@@ -318,13 +318,13 @@ export interface ClearanceExtractionResponse {
 
 /**
  * Extract ID data from uploaded image
- * Uses extended timeout (90s) since OCR processing can take 20-45 seconds
+ * Uses extended timeout (5 min) since OCR processing can take 2-4 minutes
  */
 const extractIDData = async (formData: FormData): Promise<IDExtractionResponse> => {
   const response = await apiRequest(ENDPOINTS.KYC_EXTRACT_ID, {
     method: "POST",
     body: formData as any,
-    timeout: OCR_TIMEOUT, // 90s timeout for OCR
+    timeout: OCR_TIMEOUT, // 5 min timeout for OCR
   });
 
   const data = await response.json() as { error?: string } & IDExtractionResponse;
@@ -338,13 +338,13 @@ const extractIDData = async (formData: FormData): Promise<IDExtractionResponse> 
 
 /**
  * Extract clearance data from uploaded image
- * Uses extended timeout (90s) since OCR processing can take 20-45 seconds
+ * Uses extended timeout (5 min) since OCR processing can take 2-4 minutes
  */
 const extractClearanceData = async (formData: FormData): Promise<ClearanceExtractionResponse> => {
   const response = await apiRequest(ENDPOINTS.KYC_EXTRACT_CLEARANCE, {
     method: "POST",
     body: formData as any,
-    timeout: OCR_TIMEOUT, // 90s timeout for OCR
+    timeout: OCR_TIMEOUT, // 5 min timeout for OCR
   });
 
   const data = await response.json() as { error?: string } & ClearanceExtractionResponse;


### PR DESCRIPTION
## Problem
OCR processing (Tesseract) was timing out after 90 seconds for complex or high-quality images. Real-world testing shows OCR can take 2-4 minutes for detailed documents.

## Solution
- Increased \OCR_TIMEOUT\ from **90 seconds** to **5 minutes** (300000ms)
- Updated all related comments to reflect new timeout duration

## Changes
- \lib/api/config.ts\: Updated OCR_TIMEOUT constant (90000ms → 300000ms)
- \lib/hooks/useKYCAutofill.ts\: Updated comments in extractIDData and extractClearanceData functions

## Impact
- ✅ Prevents timeout errors during KYC document extraction
- ✅ Allows Tesseract OCR to fully process complex documents
- ✅ Improves success rate for ID and clearance extraction

## Testing
- Works with existing timeout infrastructure (AbortController)
- No breaking changes - only increased timeout value