### PR TITLE
perf: Optimize mobile KYC validation to match agency speed

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx
@@ -39,7 +39,7 @@ import {
   BorderRadius,
   Shadows,
 } from "@/constants/theme";
-import { ENDPOINTS, apiRequest, OCR_TIMEOUT } from "@/lib/api/config";
+import { ENDPOINTS, apiRequest, VALIDATION_TIMEOUT, OCR_TIMEOUT } from "@/lib/api/config";
 
 // Total steps in the KYC flow
 const TOTAL_STEPS = 7;
@@ -292,10 +292,11 @@ export default function KYCUploadScreen() {
       console.log(`[KYC Validate] Validating ${documentType} at: ${endpointUrl}`);
       
       // Use apiRequest instead of raw fetch for better error handling and auto-auth
+      // Use VALIDATION_TIMEOUT (30s) instead of OCR_TIMEOUT (5min) - validation doesn't do OCR
       const response = await apiRequest(endpointUrl, {
         method: "POST",
         body: formData as any,
-        timeout: OCR_TIMEOUT, // Use 5-minute timeout for validation
+        timeout: VALIDATION_TIMEOUT, // 30s for quality checks (no OCR)
       });
 
       console.log(`[KYC Validate] Response status: ${response.status}`);

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -442,6 +442,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 // HTTP Request helper with credentials
 // API request helper with built-in timeout using AbortController
 export const DEFAULT_REQUEST_TIMEOUT = 15000; // 15 seconds
+export const VALIDATION_TIMEOUT = 30000; // 30 seconds for document validation (quality checks, no OCR)
 export const OCR_TIMEOUT = 300000; // 5 minutes for OCR extraction operations (Tesseract can take 2-4 min)
 
 export const apiRequest = async (


### PR DESCRIPTION
## Problem
Mobile KYC validate-document endpoint was extremely slow (infinite loading for back ID) compared to Agency KYC which processes quickly.

## Root Cause Analysis
Cross-referencing Agency vs Mobile KYC revealed:
1. Mobile used 5-minute OCR timeout for validation that doesn't even do OCR
2. Mobile lacked Redis caching that Agency KYC uses (instant cache hits)
3. Mobile always initialized Face API even for BACKID/CLEARANCE (no faces needed)
4. Mobile failed hard when Face API unavailable instead of fallback

## Solution
### Backend (accounts/api.py)
- Add Redis caching using agency validation_cache module (10 min TTL)
- Add fast-path for BACKID/CLEARANCE with skip_face_service=True
- Add fallback to accept for manual review if Face API unavailable
- Return file_hash and cached flag in response

### Frontend (upload.tsx + config.ts)
- Add VALIDATION_TIMEOUT constant (30 seconds)
- Use shorter timeout for validation (vs 5 min OCR timeout)

## Expected Performance Improvement
- CACHE HIT: Instant response (same file already validated)
- BACKID/CLEARANCE: 1-3s (quality check only, no face service)
- FRONTID/SELFIE: 3-10s (quality + face detection)
- Fallback: 1s (accept for manual review if service down)

## Testing
1. Upload front ID - should validate in 3-10s
2. Upload back ID - should validate in 1-3s (fast path)
3. Re-upload same file - should return instantly (cache hit)
4. Check backend logs for CACHE HIT and skip_face_service messages