### PR TITLE
fix: DatePicker for KYC date fields + 2min upload timeout

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx
@@ -39,7 +39,7 @@ import {
   BorderRadius,
   Shadows,
 } from "@/constants/theme";
-import { ENDPOINTS, apiRequest, VALIDATION_TIMEOUT, OCR_TIMEOUT } from "@/lib/api/config";
+import { ENDPOINTS, apiRequest, VALIDATION_TIMEOUT, OCR_TIMEOUT, KYC_UPLOAD_TIMEOUT } from "@/lib/api/config";
 import { compressImage } from "@/lib/utils/image-utils";
 
 // Total steps in the KYC flow
@@ -715,6 +715,7 @@ export default function KYCUploadScreen() {
       const response = await apiRequest(ENDPOINTS.KYC_UPLOAD, {
         method: "POST",
         body: formData as any, // React Native FormData compatible with apiRequest
+        timeout: KYC_UPLOAD_TIMEOUT, // 2 minutes for large file uploads
       });
 
       const responseData = (await response.json().catch(() => ({}))) as {

--- a/apps/frontend_mobile/iayos_mobile/components/KYC/KYCFieldEditor.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/KYC/KYCFieldEditor.tsx
@@ -9,8 +9,10 @@ import {
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
+  Platform,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
 import {
   Colors,
   Typography,
@@ -69,6 +71,7 @@ export const KYCFieldEditor: React.FC<KYCFieldEditorProps> = ({
   errorMessage,
 }) => {
   const [isFocused, setIsFocused] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
   
   // Determine if value was modified from OCR extraction
   const isModified = field?.value && value !== field.value;
@@ -129,42 +132,85 @@ export const KYCFieldEditor: React.FC<KYCFieldEditorProps> = ({
         )}
       </View>
       
-      {/* Input Field */}
-      <View
-        style={[
-          styles.inputContainer,
-          isFocused && styles.inputContainerFocused,
-          errorMessage && styles.inputContainerError,
-          !editable && styles.inputContainerDisabled,
-        ]}
-      >
-        <TextInput
-          style={[styles.input, !editable && styles.inputDisabled]}
-          value={value}
-          onChangeText={onValueChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          placeholder={placeholder || `Enter ${label.toLowerCase()}`}
-          placeholderTextColor={Colors.textSecondary}
-          editable={editable}
-          autoCapitalize="words"
-          autoCorrect={false}
-        />
-        
-        {/* Clear Button (when has value and editable) */}
-        {value.length > 0 && editable && (
+      {inputType === "date" ? (
+        <>
           <TouchableOpacity
-            style={styles.clearButton}
-            onPress={() => onValueChange("")}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            style={[
+              styles.inputContainer,
+              isFocused && styles.inputContainerFocused,
+              errorMessage && styles.inputContainerError,
+              !editable && styles.inputContainerDisabled,
+            ]}
+            onPress={() => editable && setShowDatePicker(true)}
+            activeOpacity={0.7}
           >
-            <Ionicons
-              name="close-circle"
-              size={20}
-              color={Colors.textSecondary}
-            />
+            <Text
+              style={[
+                styles.input,
+                { flex: 1 },
+                !value && { color: Colors.textSecondary },
+                !editable && styles.inputDisabled,
+              ]}
+            >
+              {value || placeholder || `Select ${label.toLowerCase()}`}
+            </Text>
+            <Ionicons name="calendar-outline" size={20} color={Colors.textSecondary} />
           </TouchableOpacity>
-        )}
+          
+          {showDatePicker && (
+            <DateTimePicker
+              value={value ? new Date(value) : new Date()}
+              mode="date"
+              display={Platform.OS === "ios" ? "spinner" : "default"}
+              onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
+                setShowDatePicker(Platform.OS === "ios");
+                if (event.type === "set" && selectedDate) {
+                  // Format as YYYY-MM-DD for consistent storage
+                  const formatted = selectedDate.toISOString().split("T")[0];
+                  onValueChange(formatted);
+                }
+              }}
+            />
+          )}
+        </>
+      ) : (
+        <View
+          style={[
+            styles.inputContainer,
+            isFocused && styles.inputContainerFocused,
+            errorMessage && styles.inputContainerError,
+            !editable && styles.inputContainerDisabled,
+          ]}
+        >
+          <TextInput
+            style={[styles.input, !editable && styles.inputDisabled]}
+            value={value}
+            onChangeText={onValueChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            placeholder={placeholder || `Enter ${label.toLowerCase()}`}
+            placeholderTextColor={Colors.textSecondary}
+            editable={editable}
+            autoCapitalize="words"
+            autoCorrect={false}
+          />
+          
+          {/* Clear Button (when has value and editable) */}
+          {value.length > 0 && editable && (
+            <TouchableOpacity
+              style={styles.clearButton}
+              onPress={() => onValueChange("")}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Ionicons
+                name="close-circle"
+                size={20}
+                color={Colors.textSecondary}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
       </View>
       
       {/* Error Message */}

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -444,6 +444,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 export const DEFAULT_REQUEST_TIMEOUT = 15000; // 15 seconds
 export const VALIDATION_TIMEOUT = 30000; // 30 seconds for document validation (quality checks, no OCR)
 export const OCR_TIMEOUT = 300000; // 5 minutes for OCR extraction operations (Tesseract can take 2-4 min)
+export const KYC_UPLOAD_TIMEOUT = 120000; // 2 minutes for KYC upload (multiple compressed images)
 
 export const apiRequest = async (
   url: string,


### PR DESCRIPTION
## Changes
- Add \KYC_UPLOAD_TIMEOUT\ (120s) constant for large file uploads
- Import and use timeout in \kyc/upload.tsx\ apiRequest call  
- Add DateTimePicker component for date inputType fields in KYCFieldEditor
- Date fields (birth_date, issue_date, validity_date) now show native picker
- OCR-extracted dates display properly and allow user editing

## Testing
- [ ] KYC upload no longer times out after 15s
- [ ] Date fields show native DatePicker on tap
- [ ] OCR-extracted dates populate correctly
- [ ] Edited dates save in YYYY-MM-DD format