### PR TITLE
fix: remove extra closing View tag in KYCFieldEditor

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/components/KYC/KYCFieldEditor.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/KYC/KYCFieldEditor.tsx
@@ -211,7 +211,6 @@ export const KYCFieldEditor: React.FC<KYCFieldEditorProps> = ({
           )}
         </View>
       )}
-      </View>
       
       {/* Error Message */}
       {errorMessage && (


### PR DESCRIPTION
Remove duplicate View tag causing syntax error