### PR TITLE
fix: streamline KYC upload - skip AI verification, add fileType to admin response

### DIFF
--- a/apps/backend/src/accounts/api.py
+++ b/apps/backend/src/accounts/api.py
@@ -402,13 +402,21 @@ def upload_kyc(request):
         backID = request.FILES.get("backID")
         clearance = request.FILES.get("clearance")
         selfie = request.FILES.get("selfie")
+        
+        # Get user-confirmed extraction data from per-step OCR
+        extracted_id_data = request.POST.get("extracted_id_data")
+        extracted_clearance_data = request.POST.get("extracted_clearance_data")
 
         payload = KYCUploadSchema(
             accountID=accountID,
             IDType=IDType,
             clearanceType=clearanceType
         )
-        result = upload_kyc_document(payload, frontID, backID, clearance, selfie)
+        result = upload_kyc_document(
+            payload, frontID, backID, clearance, selfie,
+            extracted_id_data=extracted_id_data,
+            extracted_clearance_data=extracted_clearance_data
+        )
         return result
     except ValueError as e:
         print(f"❌ ValueError in KYC upload: {str(e)}")

--- a/apps/backend/src/adminpanel/service.py
+++ b/apps/backend/src/adminpanel/service.py
@@ -114,14 +114,34 @@ def fetchAll_kyc(request):
         })
 
     # Serialize KYC files with proper field naming
+    # Helper function to derive fileType from fileName pattern
+    def derive_file_type(filename: str) -> str:
+        """Derive fileType from fileName pattern (FRONTID→front, BACKID→back, etc.)"""
+        if not filename:
+            return "unknown"
+        filename_upper = filename.upper()
+        if "FRONTID" in filename_upper or "FRONT_ID" in filename_upper:
+            return "front"
+        elif "BACKID" in filename_upper or "BACK_ID" in filename_upper:
+            return "back"
+        elif "SELFIE" in filename_upper:
+            return "selfie"
+        elif "CLEARANCE" in filename_upper or "NBI" in filename_upper:
+            return "clearance"
+        else:
+            return "unknown"
+    
     kyc_files_serialized = []
     for file in kyc_files:
+        file_type = derive_file_type(file.fileName)
         kyc_files_serialized.append({
             "kycFileID": file.kycFileID,
             "kycID_id": file.kycID.kycID,
             "idType": file.idType,
             "fileName": file.fileName,
             "fileURL": file.fileURL,
+            "filePath": file.fileURL,  # Alias for frontend compatibility
+            "fileType": file_type,  # Derived from fileName pattern
         })
 
     data = {


### PR DESCRIPTION
## Problem
- Upload endpoint was running full AI verification (face detection, OCR, face matching)
- This duplicated work already done by per-step /validate-document endpoint
- Caused uploads to take 60+ seconds and timeout
- Admin panel couldn't display uploaded files (missing fileType field)

## Solution
1. **Skip AI verification during upload** (skip_ai_verification=True by default)
   - Per-step validation already validated documents
   - Upload now just: upload to Supabase + save DB records

2. **Accept user-confirmed extraction data from mobile**
   - Mobile sends extracted_id_data and extracted_clearance_data
   - Store directly to KYCExtractedData (no re-extraction)

3. **Add fileType to adminpanel response**
   - Derive from fileName pattern (FRONTID→front, BACKID→back, etc.)
   - Add filePath alias for fileURL

## Result
- Upload is now fast (just file upload + DB save)
- No duplicate AI processing
- Admin panel displays all 4 KYC documents correctly

## Files Changed
- \ccounts/services.py\ - Skip AI, accept extraction data
- \ccounts/api.py\ - Pass extraction data to service
- \dminpanel/service.py\ - Add fileType and filePath fields