### PR TITLE
fix: Downgrade NDK to 26.3 and Gradle to 8.10 for Android stability

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -174,14 +174,14 @@ jobs:
           esac
 
           NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          
+
           # Check if this tag already exists and keep incrementing until we find an unused one
           cd ${{ github.workspace }}
           git fetch --tags
-          
+
           TAG_SUFFIX="${{ github.event.inputs.is_qa == 'true' && '-qa' || '' }}"
           TAG_NAME="mobile-v${NEW_VERSION}${TAG_SUFFIX}"
-          
+
           MAX_INCREMENT=10
           INCREMENT=0
           while git rev-parse "$TAG_NAME" >/dev/null 2>&1; do
@@ -196,13 +196,13 @@ jobs:
               exit 1
             fi
           done
-          
+
           if [ $INCREMENT -gt 0 ]; then
             echo "✅ Found unused version: $NEW_VERSION (incremented $INCREMENT times)"
           fi
-          
+
           cd ${{ env.MOBILE_DIR }}
-          
+
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
@@ -227,20 +227,20 @@ jobs:
       # ============================================
       # LOCAL BUILD SETUP (No EAS Cloud Credits!)
       # ============================================
-      
+
       - name: Setup Java JDK 17
         if: steps.analyze.outputs.should_release == 'true' && github.event.inputs.skip_build != 'true' && github.event.inputs.use_latest_build != 'true' && github.event.inputs.local_build != 'true'
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup Android SDK
         if: steps.analyze.outputs.should_release == 'true' && github.event.inputs.skip_build != 'true' && github.event.inputs.use_latest_build != 'true' && github.event.inputs.local_build != 'true'
         uses: android-actions/setup-android@v3
         with:
-          cmdline-tools-version: 11076708  # Latest stable
-          
+          cmdline-tools-version: 11076708 # Latest stable
+
       - name: Accept Android Licenses
         if: steps.analyze.outputs.should_release == 'true' && github.event.inputs.skip_build != 'true' && github.event.inputs.use_latest_build != 'true' && github.event.inputs.local_build != 'true'
         run: yes | sdkmanager --licenses || true
@@ -248,8 +248,8 @@ jobs:
       - name: Install Android Build Tools
         if: steps.analyze.outputs.should_release == 'true' && github.event.inputs.skip_build != 'true' && github.event.inputs.use_latest_build != 'true' && github.event.inputs.local_build != 'true'
         run: |
-          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;27.1.12297006"
-          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.1.12297006" >> $GITHUB_ENV
+          sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0" "ndk;26.3.11579264"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/26.3.11579264" >> $GITHUB_ENV
 
       - name: Build Android APK (Local - No EAS Credits!)
         if: steps.analyze.outputs.should_release == 'true' && github.event.inputs.skip_build != 'true' && github.event.inputs.use_latest_build != 'true' && github.event.inputs.local_build != 'true'
@@ -258,19 +258,19 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           BUILD_PROFILE="production"
-          
+
           echo "🏗️ LOCAL BUILD with profile: $BUILD_PROFILE"
           echo "✅ No EAS cloud credits consumed - building locally!"
-          
+
           echo "📦 Production build - ready for app store distribution"
-          
+
           # Run local build (outputs APK directly, no cloud needed!)
           # The --local flag builds on this runner instead of EAS servers
           eas build --platform android --profile $BUILD_PROFILE --local --non-interactive --output=./build-output.apk
-          
+
           # Rename to versioned filename
           mv ./build-output.apk ./iayos-${{ steps.version.outputs.new_version }}.apk
-          
+
           echo "✅ Local build complete!"
           ls -la ./iayos-${{ steps.version.outputs.new_version }}.apk
 
@@ -284,13 +284,13 @@ jobs:
           echo "   Local builds are not uploaded to Expo and cannot be reused."
           echo "   If you've been using local builds, you need to build fresh."
           echo ""
-          
+
           # Get build info
           BUILD_INFO=$(eas build:list --platform android --limit 1 --json --non-interactive 2>/dev/null || echo "[]")
           BUILD_URL=$(echo "$BUILD_INFO" | jq -r '.[0].artifacts.buildUrl // empty')
           BUILD_STATUS=$(echo "$BUILD_INFO" | jq -r '.[0].status // empty')
           BUILD_DATE=$(echo "$BUILD_INFO" | jq -r '.[0].createdAt // empty')
-          
+
           if [ -z "$BUILD_URL" ] || [ "$BUILD_URL" = "null" ]; then
             echo "❌ No existing EAS cloud build found!"
             echo ""
@@ -300,16 +300,16 @@ jobs:
             echo ""
             exit 1
           fi
-          
+
           echo "📦 Found EAS build:"
           echo "   Status: $BUILD_STATUS"
           echo "   Date: $BUILD_DATE"
           echo "   URL: $BUILD_URL"
           echo ""
-          
+
           echo "Downloading APK from: $BUILD_URL"
           curl -L --fail --retry 3 -o iayos-${{ steps.version.outputs.new_version }}.apk "$BUILD_URL"
-          
+
           echo "✅ APK downloaded successfully"
           ls -la iayos-${{ steps.version.outputs.new_version }}.apk
 
@@ -358,27 +358,27 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          
+
           # Use the version that was already verified to not have an existing tag
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
           TAG_NAME="${{ steps.version.outputs.tag_name }}"
-          
+
           echo "📦 Version: $NEW_VERSION"
           echo "🏷️ Tag: $TAG_NAME"
-          
+
           echo "final_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-          
+
           # Sync with remote first
           echo "🔄 Syncing with remote before committing..."
           git fetch origin ${{ github.ref_name }}
           git reset --hard origin/${{ github.ref_name }}
-          
+
           # Apply version changes
           cd ${{ env.MOBILE_DIR }}
-          
+
           npm version $NEW_VERSION --no-git-tag-version --allow-same-version
-          
+
           # Update app.json version
           node -e "
             const fs = require('fs');
@@ -386,12 +386,12 @@ jobs:
             appJson.expo.version = '$NEW_VERSION';
             fs.writeFileSync('app.json', JSON.stringify(appJson, null, 2) + '\n');
           "
-          
+
           cd -
-          
+
           # Now commit and push
           git add ${{ env.MOBILE_DIR }}/package.json ${{ env.MOBILE_DIR }}/app.json
-          
+
           # Check if there are changes to commit
           if git diff --cached --quiet; then
             echo "ℹ️ No version changes to commit (already at $NEW_VERSION)"

--- a/apps/frontend_mobile/iayos_mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/frontend_mobile/iayos_mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/apps/frontend_mobile/iayos_mobile/components/external-link.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/external-link.tsx
@@ -1,6 +1,7 @@
 import { Href, Link } from 'expo-router';
 import { openBrowserAsync, WebBrowserPresentationStyle } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
+import { Platform } from 'react-native';
 
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: Href & string };
 
@@ -11,7 +12,7 @@ export function ExternalLink({ href, ...rest }: Props) {
       {...rest}
       href={href}
       onPress={async (event) => {
-        if (process.env.EXPO_OS !== 'web') {
+        if (Platform.OS !== 'web') {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.


### PR DESCRIPTION
## Critical Android Crash Fix

### Root Cause Analysis
After v1.8.3 continued to crash despite previous fixes, investigation revealed:

1. **NDK 27.1.12297006 is too new** - Has compatibility issues with react-native-worklets and Reanimated 4.x
2. **Gradle 8.14.3 is bleeding-edge** - May produce corrupted native builds with RN 0.81
3. **process.env.EXPO_OS** - Build-time only, not available at runtime

### Changes

| Component | Before | After | Reason |
|-----------|--------|-------|--------|
| NDK | 27.1.12297006 | **26.3.11579264** | Stable with RN 0.81 + Reanimated 4.x |
| Gradle | 8.14.3 | **8.10** | Tested stable with RN ecosystem |
| Platform check | process.env.EXPO_OS | **Platform.OS** | Runtime vs build-time |

### Files Changed
- \.github/workflows/mobile-release.yml\ - NDK downgrade
- \ndroid/gradle/wrapper/gradle-wrapper.properties\ - Gradle downgrade
- \components/external-link.tsx\ - Platform.OS fix

### Expected Result
App should now build with proven stable toolchain and no longer crash on startup.