### PR TITLE
fix: use square icon for expo doctor validation

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "iayos",
     "version": "1.8.5",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
+    "icon": "./assets/images/android-icon-foreground.png",
     "scheme": "iayosmobile",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": false,


### PR DESCRIPTION
Fixes expo doctor error - icon.png was 3716x2437 (non-square). Now using android-icon-foreground.png which is 1971x1971 (perfectly square).