### PR TITLE
fix: re-enable New Architecture (required by Reanimated 4.x)

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/images/android-icon-foreground.png",
     "scheme": "iayosmobile",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": false,
+    "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.iayos.mobile"


### PR DESCRIPTION
Reanimated 4.x and worklets require New Architecture enabled. The actual crash fixes were:
- FileSystem legacy import fix
- Constants static import fix  
- Square icon fix

These should resolve the crashes while keeping New Architecture enabled.