### PR TITLE
fix(mobile): Extend network timeouts to 2 minutes minimum

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/components/PortfolioUpload.tsx
+++ b/apps/frontend_mobile/iayos_mobile/components/PortfolioUpload.tsx
@@ -183,7 +183,7 @@ export const PortfolioUpload: React.FC<PortfolioUploadProps> = ({
               resolve({ success: false, error: "Upload timed out" });
 
             xhr.open("POST", ENDPOINTS.UPLOAD_PORTFOLIO_IMAGE);
-            xhr.timeout = 60000;
+            xhr.timeout = 120000; // 2 minute timeout (increased for slow networks)
             xhr.setRequestHeader("Accept", "application/json");
             xhr.send(formData);
           }

--- a/apps/frontend_mobile/iayos_mobile/context/AuthContext.tsx
+++ b/apps/frontend_mobile/iayos_mobile/context/AuthContext.tsx
@@ -516,7 +516,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   // Timeout: If backend is unreachable, app still becomes interactive
   useEffect(() => {
     let isMounted = true;
-    const AUTH_TIMEOUT_MS = 5000; // 5 seconds max for auth check (reduced for faster E2E)
+    const AUTH_TIMEOUT_MS = 120000; // 2 minutes max for auth check (increased for slow networks)
     const isE2EMode = process.env.EXPO_PUBLIC_E2E_MODE === "true";
 
     const initializeAuth = async () => {

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -434,7 +434,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // HTTP Request helper with credentials
 // API request helper with built-in timeout using AbortController
-export const DEFAULT_REQUEST_TIMEOUT = 15000; // 15 seconds
+export const DEFAULT_REQUEST_TIMEOUT = 120000; // 2 minutes (increased for slow networks)
 export const VALIDATION_TIMEOUT = 300000; // 5 minutes for document validation (Render cold start + processing)
 export const OCR_TIMEOUT = 300000; // 5 minutes for OCR extraction operations (Tesseract can take 2-4 min)
 export const KYC_UPLOAD_TIMEOUT = 300000; // 5 minutes for KYC upload (multiple compressed images)

--- a/apps/frontend_mobile/iayos_mobile/lib/hooks/useImageUpload.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/hooks/useImageUpload.ts
@@ -142,7 +142,7 @@ export const useImageUpload = () => {
 
           // Configure and send request
           xhr.open("POST", fullEndpoint);
-          xhr.timeout = 60000; // 60 second timeout
+          xhr.timeout = 120000; // 2 minute timeout (increased for slow networks)
           xhr.setRequestHeader("Accept", "application/json");
 
           // Add Authorization header for authenticated uploads
@@ -288,7 +288,7 @@ export const useMultiImageUpload = () => {
 
             // Configure and send request
             xhr.open("POST", fullEndpoint);
-            xhr.timeout = 60000;
+            xhr.timeout = 120000; // 2 minute timeout (increased for slow networks)
             xhr.setRequestHeader("Accept", "application/json");
 
             // Add Authorization header

--- a/apps/frontend_mobile/iayos_mobile/lib/hooks/useUnreadCounts.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/hooks/useUnreadCounts.ts
@@ -14,7 +14,7 @@ export function useUnreadMessageCount() {
         const response = await apiRequest(
           `${ENDPOINTS.CONVERSATIONS}?unread=true`,
           {
-            timeout: 10000,
+            timeout: 120000, // 2 minute timeout (increased for slow networks)
           }
         );
 
@@ -50,7 +50,7 @@ export function useUnreadNotificationCount() {
         const response = await apiRequest(
           ENDPOINTS.UNREAD_NOTIFICATIONS_COUNT,
           {
-            timeout: 10000,
+            timeout: 120000, // 2 minute timeout (increased for slow networks)
           }
         );
 


### PR DESCRIPTION
## Summary
Fixes 'Network Request timed out after 15000ms' errors on slow networks by increasing all network timeouts to 2 minutes (120,000ms) as the minimum.

## Changes Made

| File | Change |
|------|--------|
| lib/api/config.ts | DEFAULT_REQUEST_TIMEOUT: 15s -> 120s |
| lib/hooks/useImageUpload.ts | XHR timeout: 60s -> 120s (both single and multi-image) |
| components/PortfolioUpload.tsx | XHR timeout: 60s -> 120s |
| lib/hooks/useUnreadCounts.ts | API timeout: 10s -> 120s (messages and notifications) |
| context/AuthContext.tsx | Auth check timeout: 5s -> 120s |

## Unchanged
KYC/OCR/Validation timeouts remain at 5 minutes (300s) - these were already higher than the 2-minute minimum.

## Testing
- [ ] Test on slow network connection
- [ ] Verify app does not hang indefinitely
- [ ] Confirm requests complete successfully with extended timeout