### PR TITLE
fix(android): Add network security config for production builds

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -39,6 +39,15 @@
     "plugins": [
       "expo-router",
       [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true,
+            "networkSecurityConfig": "./network-security-config.xml"
+          }
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -4,7 +4,7 @@
 // For Android Emulator, use 10.0.2.2
 // For physical device, use your machine's network IP
 
-import { Platform } from "react-native";
+import { Platform, Alert } from "react-native";
 import NetInfo from "@react-native-community/netinfo";
 import Constants from "expo-constants";
 
@@ -54,6 +54,19 @@ console.log(`[API Config] __DEV__ = ${__DEV__}, Platform = ${Platform.OS}`);
 console.log(
   `[API Config] EXPO_PUBLIC_API_URL = ${process.env.EXPO_PUBLIC_API_URL || "(not set)"}`,
 );
+
+// DEBUG: Show alert in production builds to verify API URL configuration
+// Remove this after confirming the network issue is resolved
+if (!__DEV__) {
+  // Delay alert to ensure app is fully loaded
+  setTimeout(() => {
+    Alert.alert(
+      "API Debug Info",
+      `URL: ${API_URL}\nPlatform: ${Platform.OS}\nENV: ${process.env.EXPO_PUBLIC_API_URL || "not set"}`,
+      [{ text: "OK" }],
+    );
+  }, 2000);
+}
 
 /**
  * Check network connectivity before making requests.

--- a/apps/frontend_mobile/iayos_mobile/network-security-config.xml
+++ b/apps/frontend_mobile/iayos_mobile/network-security-config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Default configuration: Only allow HTTPS connections -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+    
+    <!-- Allow connections to iayos.online domains -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">iayos.online</domain>
+        <domain includeSubdomains="true">api.iayos.online</domain>
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </domain-config>
+    
+    <!-- Debug/Development: Allow local network for Expo Go (only in debug builds) -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/apps/frontend_mobile/iayos_mobile/package.json
+++ b/apps/frontend_mobile/iayos_mobile/package.json
@@ -29,6 +29,7 @@
     "expo-file-system": "~19.0.19",
     "expo-font": "~14.0.9",
     "expo-haptics": "~15.0.8",
+    "expo-build-properties": "~0.14.6",
     "expo-image": "~3.0.11",
     "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "~17.0.10",


### PR DESCRIPTION
## Problem
Android production builds cannot reach the backend (https://api.iayos.online), while:
- Next.js web app works fine
- Expo Go development mode works fine

## Root Cause
Android 9+ requires explicit network security configuration. Production builds were missing:
1. \expo-build-properties\ plugin for Android native configuration
2. Custom \
etwork-security-config.xml\ to allow HTTPS connections

## Changes

### 1. Added \expo-build-properties\ plugin
- Installed \expo-build-properties@~0.14.6\
- Configured in \pp.json\ plugins array

### 2. Created \
etwork-security-config.xml\
- Allows secure HTTPS connections to \*.iayos.online\
- Trusts system CA certificates
- Debug overrides for development flexibility

### 3. Added Debug Alert (Temporary)
- Shows API URL in production builds on app start
- Helps verify the correct URL is being used
- **Remove after confirming fix works**

## Files Changed
- \pp.json\ - Added expo-build-properties plugin
- \package.json\ - Added expo-build-properties dependency
- \lib/api/config.ts\ - Added debug alert for production
- \
etwork-security-config.xml\ - New file for Android network security

## Testing
After merging:
1. Run \eas build --profile production --platform android\
2. Install APK on physical device
3. Verify debug alert shows correct URL: \https://api.iayos.online\
4. Test login functionality
5. If working, remove debug alert in follow-up PR