### PR TITLE
feat: add barangay field to registration forms with prefilled location fields

### DIFF
--- a/apps/backend/src/accounts/models.py
+++ b/apps/backend/src/accounts/models.py
@@ -65,6 +65,7 @@ class Accounts(AbstractBaseUser, PermissionsMixin):  # <-- include PermissionsMi
     email_otp_attempts = models.IntegerField(default=0)  # Max 5 failed attempts
     
     street_address = models.CharField(max_length=255, default="", blank=True)   # "123 Main St"
+    barangay = models.CharField(max_length=100, default="", blank=True)         # "Tetuan"
     city = models.CharField(max_length=100, default="", blank=True)             # "Zamboanga City"
     province = models.CharField(max_length=100, default="", blank=True)         # "Zamboanga del Sur"
     postal_code = models.CharField(max_length=20, default="", blank=True)       # "7000"
@@ -129,6 +130,7 @@ class Agency(models.Model):
     accountFK = models.ForeignKey(Accounts, on_delete=models.CASCADE)
     businessName = models.CharField(max_length=50)
     street_address = models.CharField(max_length=255, default="", blank=True)   # "123 Main St"
+    barangay = models.CharField(max_length=100, default="", blank=True)         # "Tetuan"
     city = models.CharField(max_length=100, default="", blank=True)             # "Zamboanga City"
     province = models.CharField(max_length=100, default="", blank=True)         # "Zamboanga del Sur"
     postal_code = models.CharField(max_length=20, default="", blank=True)

--- a/apps/backend/src/accounts/schemas.py
+++ b/apps/backend/src/accounts/schemas.py
@@ -15,6 +15,7 @@ class createAccountSchema(Schema):
     email: EmailStr
     password: str
     street_address: str
+    barangay: str             # "Tetuan"
     city: str             # "Zamboanga City"
     province: str        # "Zamboanga del Sur"
     postal_code: str    # Changed from int to str to match Accounts model CharField
@@ -36,6 +37,7 @@ class createAgencySchema(Schema):
     password: str
     businessName: str
     street_address: str
+    barangay: str             # "Tetuan"
     city: str             # "Zamboanga City"
     province: str        # "Zamboanga del Sur"
     postal_code: str    # "7000"

--- a/apps/backend/src/accounts/services.py
+++ b/apps/backend/src/accounts/services.py
@@ -75,6 +75,7 @@ def create_account_individ(data):
         email=data.email,
         password=data.password,
         street_address=data.street_address,
+        barangay=data.barangay,
         city=data.city,
         province=data.province,
         postal_code=data.postal_code,
@@ -149,6 +150,11 @@ def create_account_agency(data):
     profile = Agency.objects.create(
         accountFK=user,
         businessName=data.businessName,
+        street_address=data.street_address,
+        barangay=data.barangay,
+        city=data.city,
+        province=data.province,
+        postal_code=data.postal_code,
         businessDesc=""  # Provide empty string for required field
     )
 

--- a/apps/frontend_mobile/iayos_mobile/app/auth/register.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/auth/register.tsx
@@ -11,6 +11,9 @@ import {
   Alert,
   Keyboard,
   TextInput as RNTextInput,
+  Modal,
+  FlatList,
+  ActivityIndicator,
 } from "react-native";
 import DateTimePicker, {
   DateTimePickerEvent,
@@ -27,6 +30,7 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import { useBarangays } from "@/lib/hooks/useLocations";
 
 const DEFAULT_COUNTRY = "Philippines";
 const MIN_PASSWORD_LENGTH = 8;
@@ -51,13 +55,24 @@ export default function RegisterScreen() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [streetAddress, setStreetAddress] = useState("");
-  const [city, setCity] = useState("");
-  const [province, setProvince] = useState("");
-  const [postalCode, setPostalCode] = useState("");
+  const [barangay, setBarangay] = useState("");
+  const [barangayModalVisible, setBarangayModalVisible] = useState(false);
+  const [city, setCity] = useState("Zamboanga City");
+  const [province, setProvince] = useState("Zamboanga del Sur");
+  const [postalCode, setPostalCode] = useState("7000");
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { register } = useAuth();
   const router = useRouter();
+
+  // Fetch barangays for Zamboanga City (cityID = 1)
+  const {
+    data: barangaysData,
+    isLoading: barangaysLoading,
+    error: barangaysError,
+  } = useBarangays(1);
+  const barangays = barangaysData || [];
+
   const adultCutoffDate = useMemo(() => {
     const today = new Date();
     return new Date(
@@ -157,6 +172,7 @@ export default function RegisterScreen() {
     const trimmedLast = lastName.trim();
     const trimmedEmail = email.trim().toLowerCase();
     const trimmedStreet = streetAddress.trim();
+    const trimmedBarangay = barangay.trim();
     const trimmedCity = city.trim();
     const trimmedProvince = province.trim();
     const trimmedPostal = postalCode.trim();
@@ -253,8 +269,8 @@ export default function RegisterScreen() {
       return;
     }
 
-    if (!trimmedStreet || !trimmedCity || !trimmedProvince) {
-      Alert.alert("Error", "Street address, city, and province are required");
+    if (!trimmedStreet || !trimmedBarangay || !trimmedCity || !trimmedProvince) {
+      Alert.alert("Error", "Street address, barangay, city, and province are required");
       return;
     }
 
@@ -275,6 +291,7 @@ export default function RegisterScreen() {
         password,
         confirmPassword,
         street_address: trimmedStreet,
+        barangay: trimmedBarangay,
         city: trimmedCity,
         province: trimmedProvince,
         postal_code: trimmedPostal,
@@ -654,15 +671,115 @@ export default function RegisterScreen() {
             <View style={styles.sectionHeader}>
               <Text style={styles.sectionTitle}>Address Information</Text>
               <Text style={styles.sectionSubtitle}>
-                We currently support addresses within the Philippines.
+                We currently support addresses within Zamboanga City.
               </Text>
             </View>
+
+            {/* Barangay Dropdown */}
+            <View style={styles.inputGroup}>
+              <Text style={styles.inputLabel}>
+                Barangay <Text style={styles.required}>*</Text>
+              </Text>
+              {barangaysLoading ? (
+                <View style={styles.barangayButton}>
+                  <ActivityIndicator size="small" color={Colors.primary} />
+                  <Text style={styles.barangayButtonPlaceholder}>
+                    Loading barangays...
+                  </Text>
+                </View>
+              ) : barangaysError ? (
+                <View style={styles.barangayButton}>
+                  <Text style={styles.barangayButtonPlaceholder}>
+                    ⚠️ Failed to load barangays
+                  </Text>
+                </View>
+              ) : (
+                <TouchableOpacity
+                  style={styles.barangayButton}
+                  onPress={() => setBarangayModalVisible(true)}
+                  activeOpacity={0.7}
+                  disabled={isLoading}
+                >
+                  <Ionicons
+                    name="location-outline"
+                    size={20}
+                    color={Colors.primary}
+                    style={styles.barangayIcon}
+                  />
+                  <Text
+                    style={
+                      barangay
+                        ? styles.barangayButtonText
+                        : styles.barangayButtonPlaceholder
+                    }
+                  >
+                    {barangay || "Select a barangay"}
+                  </Text>
+                  <Ionicons
+                    name="chevron-down"
+                    size={20}
+                    color={Colors.textSecondary}
+                  />
+                </TouchableOpacity>
+              )}
+            </View>
+
+            {/* Barangay Selection Modal */}
+            <Modal
+              visible={barangayModalVisible}
+              animationType="slide"
+              transparent={true}
+              onRequestClose={() => setBarangayModalVisible(false)}
+            >
+              <View style={styles.modalOverlay}>
+                <View style={styles.modalContent}>
+                  <View style={styles.modalHeader}>
+                    <Text style={styles.modalTitle}>Select Barangay</Text>
+                    <TouchableOpacity
+                      onPress={() => setBarangayModalVisible(false)}
+                      style={styles.modalCloseButton}
+                    >
+                      <Ionicons name="close" size={24} color={Colors.textPrimary} />
+                    </TouchableOpacity>
+                  </View>
+                  <FlatList
+                    data={barangays}
+                    keyExtractor={(item) => item.barangayID.toString()}
+                    renderItem={({ item }) => (
+                      <TouchableOpacity
+                        style={[
+                          styles.barangayItem,
+                          barangay === item.name && styles.barangayItemSelected,
+                        ]}
+                        onPress={() => {
+                          setBarangay(item.name);
+                          setBarangayModalVisible(false);
+                        }}
+                      >
+                        <Text
+                          style={[
+                            styles.barangayItemText,
+                            barangay === item.name && styles.barangayItemTextSelected,
+                          ]}
+                        >
+                          {item.name}
+                        </Text>
+                        {barangay === item.name && (
+                          <Ionicons name="checkmark" size={20} color={Colors.primary} />
+                        )}
+                      </TouchableOpacity>
+                    )}
+                    showsVerticalScrollIndicator={true}
+                  />
+                </View>
+              </View>
+            </Modal>
 
             {/* Street Address */}
             <Input
               ref={streetAddressRef}
               label="Street Address"
-              placeholder="House no., Street name, Barangay"
+              placeholder="House no., Street name"
               value={streetAddress}
               onChangeText={setStreetAddress}
               editable={!isLoading}
@@ -680,44 +797,34 @@ export default function RegisterScreen() {
               }}
             />
 
-            {/* City */}
+            {/* City (Pre-filled, disabled) */}
             <Input
               ref={cityRef}
-              label="City"
-              placeholder="e.g., Zamboanga City"
+              label="City (Pre-filled)"
+              placeholder="Zamboanga City"
               value={city}
-              onChangeText={setCity}
-              editable={!isLoading}
-              autoCapitalize="words"
+              editable={false}
               required
               iconLeft={
                 <Ionicons
                   name="business-outline"
                   size={20}
-                  color={Colors.primary}
+                  color={Colors.textSecondary}
                 />
               }
-              onFocus={() => {
-                lastFocusedRef.current = cityRef;
-              }}
             />
 
-            {/* Province */}
+            {/* Province (Pre-filled, disabled) */}
             <Input
               ref={provinceRef}
-              label="Province"
-              placeholder="e.g., Zamboanga del Sur"
+              label="Province (Pre-filled)"
+              placeholder="Zamboanga del Sur"
               value={province}
-              onChangeText={setProvince}
-              editable={!isLoading}
-              autoCapitalize="words"
+              editable={false}
               required
               iconLeft={
-                <Ionicons name="map-outline" size={20} color={Colors.primary} />
+                <Ionicons name="map-outline" size={20} color={Colors.textSecondary} />
               }
-              onFocus={() => {
-                lastFocusedRef.current = provinceRef;
-              }}
             />
 
             {/* Country */}
@@ -730,32 +837,26 @@ export default function RegisterScreen() {
                 <Ionicons
                   name="flag-outline"
                   size={20}
-                  color={Colors.primary}
+                  color={Colors.textSecondary}
                 />
               }
             />
 
-            {/* Postal Code */}
+            {/* Postal Code (Pre-filled, disabled) */}
             <Input
               ref={postalCodeRef}
-              label="Postal Code"
+              label="Postal Code (Pre-filled)"
               placeholder="7000"
               value={postalCode}
-              onChangeText={handlePostalCodeChange}
-              keyboardType="number-pad"
-              maxLength={4}
-              editable={!isLoading}
+              editable={false}
               required
               iconLeft={
                 <Ionicons
                   name="mail-open-outline"
                   size={20}
-                  color={Colors.primary}
+                  color={Colors.textSecondary}
                 />
               }
-              onFocus={() => {
-                lastFocusedRef.current = postalCodeRef;
-              }}
             />
 
             {/* Register Button */}
@@ -963,5 +1064,91 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginTop: Spacing.lg,
     fontStyle: "italic",
+  },
+  // Barangay Dropdown Styles
+  inputGroup: {
+    marginBottom: Spacing.md,
+  },
+  inputLabel: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: "600",
+    color: Colors.textPrimary,
+    marginBottom: Spacing.xs,
+  },
+  required: {
+    color: Colors.error,
+  },
+  barangayButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: Colors.white,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.md,
+    minHeight: 52,
+  },
+  barangayIcon: {
+    marginRight: Spacing.sm,
+  },
+  barangayButtonText: {
+    flex: 1,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  barangayButtonPlaceholder: {
+    flex: 1,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textHint,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "flex-end",
+  },
+  modalContent: {
+    backgroundColor: Colors.white,
+    borderTopLeftRadius: BorderRadius.xl,
+    borderTopRightRadius: BorderRadius.xl,
+    maxHeight: "70%",
+    paddingBottom: Spacing["2xl"],
+  },
+  modalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  modalTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: "700",
+    color: Colors.textPrimary,
+  },
+  modalCloseButton: {
+    padding: Spacing.xs,
+  },
+  barangayItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  barangayItemSelected: {
+    backgroundColor: Colors.primaryLight || "#E8F5E9",
+  },
+  barangayItemText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  barangayItemTextSelected: {
+    color: Colors.primary,
+    fontWeight: "600",
   },
 });

--- a/apps/frontend_mobile/iayos_mobile/types/index.ts
+++ b/apps/frontend_mobile/iayos_mobile/types/index.ts
@@ -150,6 +150,7 @@ export interface RegisterPayload {
   password: string;
   confirmPassword: string;
   street_address: string;
+  barangay: string;
   city: string;
   province: string;
   postal_code: string;

--- a/apps/frontend_web/app/auth/register/agency/page.tsx
+++ b/apps/frontend_web/app/auth/register/agency/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
+import { useBarangays } from "@/lib/hooks/useLocations";
 
 // Agency registration form schema
 const agencyFormSchema = z
@@ -43,6 +44,9 @@ const agencyFormSchema = z
       .string()
       .min(5, "Street address must be at least 5 characters")
       .max(255, "Street address must be less than 255 characters"),
+    barangay: z
+      .string()
+      .min(1, "Barangay is required"),
     city: z
       .string()
       .min(2, "City must be at least 2 characters")
@@ -75,6 +79,7 @@ const AgencyRegister = () => {
       password: "",
       confirmPassword: "",
       street_address: "",
+      barangay: "",
       city: "Zamboanga City",
       province: "Zamboanga del Sur",
       postal_code: "7000",
@@ -87,6 +92,10 @@ const AgencyRegister = () => {
   const [rateLimitTime, setRateLimitTime] = useState(0);
   const [registrationSuccess, setRegistrationSuccess] = useState(false);
   const [registeredEmail, setRegisteredEmail] = useState("");
+  
+  // Fetch barangays for Zamboanga City (cityID = 1)
+  const { data: barangays, isLoading: barangaysLoading } = useBarangays(1);
+  
   // State for resend verification email functionality
   const [verificationData, setVerificationData] = useState<{
     email: string;
@@ -251,6 +260,7 @@ const AgencyRegister = () => {
       email: values.email || "",
       password: values.password || "",
       street_address: values.street_address || "",
+      barangay: values.barangay || "",
       city: values.city || "Zamboanga City",
       province: values.province || "Zamboanga del Sur",
       postal_code: values.postal_code || "7000",
@@ -800,6 +810,37 @@ const AgencyRegister = () => {
                                   className="h-12"
                                   {...field}
                                 />
+                              </FormControl>
+                              <FormMessage className="font-inter text-xs text-red-500" />
+                            </FormItem>
+                          )}
+                        />
+
+                        <FormField
+                          control={agencyForm.control}
+                          name="barangay"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel className="font-inter text-sm font-medium text-gray-700">
+                                Barangay
+                                <span className="text-red-500 ml-1">*</span>
+                              </FormLabel>
+                              <FormControl>
+                                <select
+                                  className="w-full h-12 px-3 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                                  value={field.value}
+                                  onChange={field.onChange}
+                                  disabled={barangaysLoading}
+                                >
+                                  <option value="">
+                                    {barangaysLoading ? "Loading barangays..." : "Select a barangay"}
+                                  </option>
+                                  {barangays?.map((barangay) => (
+                                    <option key={barangay.barangayID} value={barangay.name}>
+                                      {barangay.name}
+                                    </option>
+                                  ))}
+                                </select>
                               </FormControl>
                               <FormMessage className="font-inter text-xs text-red-500" />
                             </FormItem>


### PR DESCRIPTION
## Summary
Adds barangay dropdown to both mobile and agency registration forms, and prefills City/Province/Postal Code as readonly fields.

## Changes

### Backend
- Add barangay CharField to Accounts and Agency models
- Add barangay to createAccountSchema and createAgencySchema
- Update create_account_individ() and create_account_agency() to save barangay

### Mobile (React Native)
- Import useBarangays hook
- Add barangay dropdown modal with FlatList
- Prefill city=Zamboanga City, province=Zamboanga del Sur, postal_code=7000
- Make city/province/postal_code readonly (editable=false)
- Add barangay validation and include in register() call
- Update RegisterPayload type

### Agency (Next.js)
- Add barangay to zod schema (required)
- Add barangay to defaultValues
- Add barangay dropdown using useBarangays(1) hook
- Include barangay in submission data

## Testing
- Mobile registration with barangay selection
- Agency registration with barangay selection
- Backend migration runs automatically (Docker)
- Verify data saved correctly in DB