### PR TITLE
feat: GCash Direct Deposit (Testing) + Friday Auto-Withdrawal System

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -257,7 +257,9 @@ RUN sed -i 's/\r$//' patch_ninja.sh && chmod +x patch_ninja.sh && ./patch_ninja.
 RUN chown -R appuser:appgroup /app
 
 # Setup cron job for payment buffer release (runs every hour)
+# Also setup Friday auto-withdrawal job (10:00 AM Philippines = 02:00 UTC)
 RUN echo "0 * * * * cd /app/apps/backend/src && /usr/local/bin/python manage.py release_pending_payments >> /var/log/cron.log 2>&1" > /etc/cron.d/payment-release \
+    && echo "0 2 * * 5 cd /app/apps/backend/src && /usr/local/bin/python manage.py process_auto_withdrawals >> /var/log/cron.log 2>&1" >> /etc/cron.d/payment-release \
     && chmod 0644 /etc/cron.d/payment-release \
     && crontab /etc/cron.d/payment-release \
     && touch /var/log/cron.log \

--- a/apps/backend/src/accounts/management/commands/process_auto_withdrawals.py
+++ b/apps/backend/src/accounts/management/commands/process_auto_withdrawals.py
@@ -1,0 +1,210 @@
+"""
+Django Management Command: process_auto_withdrawals
+
+Creates automatic withdrawal requests for users with auto-withdraw enabled.
+Run this command via cron job every Friday at 10:00 AM Philippines time:
+    0 2 * * 5 cd /path/to/app && python manage.py process_auto_withdrawals
+
+Features:
+- Finds wallets with autoWithdrawEnabled=True and balance >= ₱100
+- Creates PENDING withdrawal transactions (admin processes manually)
+- Skips wallets without valid payment method (and notifies user)
+- Does NOT call Xendit/PayMongo disbursement (admin processes manually)
+- Logs all actions for audit trail
+- Supports --dry-run mode for testing
+
+Usage:
+    python manage.py process_auto_withdrawals              # Process all eligible
+    python manage.py process_auto_withdrawals --dry-run    # Preview without processing
+    python manage.py process_auto_withdrawals --verbose    # Show detailed output
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from django.db import transaction
+from decimal import Decimal
+
+
+class Command(BaseCommand):
+    help = 'Create automatic withdrawal requests for users with auto-withdraw enabled (every Friday)'
+    
+    # Minimum balance required for auto-withdrawal (in PHP)
+    MIN_AUTO_WITHDRAW_AMOUNT = Decimal('100.00')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Preview withdrawals without actually processing them',
+        )
+        parser.add_argument(
+            '--verbose',
+            action='store_true',
+            help='Show detailed output for each wallet processed',
+        )
+        parser.add_argument(
+            '--limit',
+            type=int,
+            default=500,
+            help='Maximum number of wallets to process in one run (default: 500)',
+        )
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            help='Force run even if not Friday (for testing)',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        verbose = options['verbose']
+        limit = options['limit']
+        force = options['force']
+        
+        now = timezone.now()
+        
+        # Check if it's Friday (weekday 4 = Friday, 0 = Monday)
+        if not force and now.weekday() != 4:
+            self.stdout.write(self.style.WARNING(
+                f"Today is not Friday (day {now.weekday()}). Use --force to run anyway."
+            ))
+            return
+        
+        self.stdout.write(self.style.NOTICE(
+            f"{'[DRY RUN] ' if dry_run else ''}Starting auto-withdrawal job at {now.strftime('%Y-%m-%d %H:%M:%S')}"
+        ))
+        
+        try:
+            from accounts.models import Wallet, Transaction, Notification, UserPaymentMethod
+            
+            # Find eligible wallets
+            eligible_wallets = Wallet.objects.filter(
+                autoWithdrawEnabled=True,
+                balance__gte=self.MIN_AUTO_WITHDRAW_AMOUNT
+            ).select_related(
+                'accountFK',
+                'preferredPaymentMethodID'
+            )[:limit]
+            
+            if not eligible_wallets:
+                self.stdout.write(self.style.SUCCESS(
+                    "No wallets eligible for auto-withdrawal."
+                ))
+                return
+            
+            self.stdout.write(f"Found {len(eligible_wallets)} wallet(s) eligible for auto-withdrawal.")
+            
+            processed_count = 0
+            skipped_count = 0
+            failed_count = 0
+            total_amount = Decimal('0.00')
+            
+            for wallet in eligible_wallets:
+                user = wallet.accountFK
+                user_email = user.email
+                
+                if verbose:
+                    self.stdout.write(f"\n  Processing wallet for: {user_email}")
+                    self.stdout.write(f"    Balance: ₱{wallet.balance}")
+                
+                # Check for valid payment method
+                payment_method = wallet.preferredPaymentMethodID
+                if not payment_method:
+                    # Try to find any active GCash payment method
+                    payment_method = UserPaymentMethod.objects.filter(
+                        accountFK=user,
+                        methodType='GCASH'
+                    ).first()
+                
+                if not payment_method:
+                    # Skip and notify user
+                    skipped_count += 1
+                    if verbose:
+                        self.stdout.write(self.style.WARNING(
+                            f"    ⚠️ SKIPPED - No payment method found"
+                        ))
+                    
+                    if not dry_run:
+                        # Create notification for user
+                        Notification.objects.create(
+                            accountFK=user,
+                            title="Auto-Withdrawal Skipped",
+                            message=(
+                                f"Your weekly auto-withdrawal of ₱{wallet.balance:.2f} was skipped because "
+                                f"you don't have a GCash account set up. Please add a payment method."
+                            ),
+                            notificationType='PAYMENT'
+                        )
+                    continue
+                
+                withdraw_amount = wallet.balance
+                
+                if dry_run:
+                    self.stdout.write(self.style.WARNING(
+                        f"    [DRY RUN] Would create withdrawal request for ₱{withdraw_amount}"
+                    ))
+                    processed_count += 1
+                    total_amount += withdraw_amount
+                    continue
+                
+                # Create the withdrawal request (same logic as manual withdrawal)
+                try:
+                    with transaction.atomic():
+                        # Deduct balance
+                        wallet.balance -= withdraw_amount
+                        wallet.lastAutoWithdrawAt = now
+                        wallet.save()
+                        
+                        # Determine payment method display
+                        if payment_method.methodType == 'GCASH':
+                            method_display = f"GCash ({payment_method.accountNumber})"
+                        else:
+                            method_display = f"Bank ({payment_method.accountNumber})"
+                        
+                        # Create PENDING transaction
+                        tx = Transaction.objects.create(
+                            walletID=wallet,
+                            transactionType=Transaction.TransactionType.WITHDRAWAL,
+                            amount=withdraw_amount,
+                            balanceAfter=wallet.balance,
+                            status=Transaction.TransactionStatus.PENDING,
+                            description=f"Auto-Withdrawal (Friday) to {method_display}",
+                            paymentMethod=payment_method.methodType
+                        )
+                        
+                        # Create notification for user
+                        Notification.objects.create(
+                            accountFK=user,
+                            title="Auto-Withdrawal Request Created",
+                            message=(
+                                f"A withdrawal request for ₱{withdraw_amount:.2f} has been created "
+                                f"and is pending admin approval. You will be notified when processed."
+                            ),
+                            notificationType='PAYMENT'
+                        )
+                        
+                        processed_count += 1
+                        total_amount += withdraw_amount
+                        
+                        if verbose:
+                            self.stdout.write(self.style.SUCCESS(
+                                f"    ✅ Created withdrawal request #{tx.transactionID} for ₱{withdraw_amount}"
+                            ))
+                
+                except Exception as e:
+                    failed_count += 1
+                    self.stdout.write(self.style.ERROR(
+                        f"    ❌ FAILED: {str(e)}"
+                    ))
+            
+            # Summary
+            self.stdout.write("\n" + "=" * 50)
+            self.stdout.write(self.style.SUCCESS(
+                f"{'[DRY RUN] ' if dry_run else ''}Auto-withdrawal job completed:"
+            ))
+            self.stdout.write(f"  ✅ Processed: {processed_count} withdrawal request(s)")
+            self.stdout.write(f"  ⚠️ Skipped (no payment method): {skipped_count}")
+            self.stdout.write(f"  ❌ Failed: {failed_count}")
+            self.stdout.write(f"  💰 Total amount: ₱{total_amount:.2f}")
+            
+        except Exception as e:
+            raise CommandError(f"Auto-withdrawal job failed: {str(e)}")

--- a/apps/backend/src/accounts/migrations/0082_wallet_auto_withdraw_fields.py
+++ b/apps/backend/src/accounts/migrations/0082_wallet_auto_withdraw_fields.py
@@ -1,0 +1,47 @@
+# Generated manually for wallet auto-withdrawal fields
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0081_support_ticket_agency_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='wallet',
+            name='autoWithdrawEnabled',
+            field=models.BooleanField(
+                default=False,
+                help_text='If True, wallet balance will be automatically withdrawn every Friday'
+            ),
+        ),
+        migrations.AddField(
+            model_name='wallet',
+            name='preferredPaymentMethodID',
+            field=models.ForeignKey(
+                blank=True,
+                help_text='Preferred payment method for auto-withdrawals',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='preferred_for_wallets',
+                to='accounts.userpaymentmethod'
+            ),
+        ),
+        migrations.AddField(
+            model_name='wallet',
+            name='lastAutoWithdrawAt',
+            field=models.DateTimeField(
+                blank=True,
+                help_text='Timestamp of last auto-withdrawal',
+                null=True
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='wallet',
+            index=models.Index(fields=['autoWithdrawEnabled'], name='accounts_wa_autoWit_idx'),
+        ),
+    ]

--- a/apps/backend/src/accounts/models.py
+++ b/apps/backend/src/accounts/models.py
@@ -2245,6 +2245,25 @@ class Wallet(models.Model):
         help_text="Earnings from completed jobs pending release (7-day buffer)"
     )
     
+    # Auto-Withdrawal Settings (Friday weekly auto-withdrawal requests)
+    autoWithdrawEnabled = models.BooleanField(
+        default=False,
+        help_text="Enable automatic weekly withdrawal requests every Friday"
+    )
+    preferredPaymentMethodID = models.ForeignKey(
+        'UserPaymentMethod',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='auto_withdraw_wallets',
+        help_text="Preferred payment method for auto-withdrawals"
+    )
+    lastAutoWithdrawAt = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="Last time an auto-withdrawal request was created"
+    )
+    
     # Timestamps
     createdAt = models.DateTimeField(auto_now_add=True)
     updatedAt = models.DateTimeField(auto_now=True)
@@ -2252,6 +2271,7 @@ class Wallet(models.Model):
     class Meta:
         indexes = [
             models.Index(fields=['accountFK']),
+            models.Index(fields=['autoWithdrawEnabled']),
         ]
     
     @property

--- a/apps/backend/src/accounts/paymongo_service.py
+++ b/apps/backend/src/accounts/paymongo_service.py
@@ -236,6 +236,40 @@ class PayMongoService(PaymentProviderInterface):
             metadata={"payment_type": "wallet_deposit"}
         )
     
+    # TODO: REMOVE FOR PROD - Testing only GCash direct payment
+    # This method bypasses QR PH and redirects directly to GCash app
+    # Use this when QR PH doesn't work in PayMongo test mode
+    def create_gcash_direct_payment(
+        self,
+        amount: float,
+        user_email: str,
+        user_name: str,
+        transaction_id: int,
+        description: str = None,
+        success_url: str = None,
+        failure_url: str = None
+    ) -> Dict[str, Any]:
+        """
+        TODO: REMOVE FOR PROD - Testing only
+        Create direct GCash payment for testing deposits.
+        Unlike QR PH, this redirects directly to GCash app/web.
+        Only available when TESTING=true in environment.
+        """
+        frontend_url = getattr(settings, 'FRONTEND_URL', 'http://localhost:3000')
+        
+        return self.create_checkout_session(
+            amount=amount,
+            currency="PHP",
+            description=description or f"Wallet Deposit (GCash) - ₱{amount}",
+            user_email=user_email,
+            user_name=user_name,
+            transaction_id=transaction_id,
+            payment_methods=["gcash"],  # Direct GCash - redirects to GCash app
+            success_url=success_url or f"{frontend_url}/dashboard/profile?payment=success",
+            failure_url=failure_url or f"{frontend_url}/dashboard/profile?payment=failed",
+            metadata={"payment_type": "wallet_deposit", "method": "gcash_direct"}
+        )
+    
     def create_escrow_payment(
         self,
         amount: float,

--- a/apps/backend/src/iayos_project/settings.py
+++ b/apps/backend/src/iayos_project/settings.py
@@ -148,6 +148,11 @@ APP_VERSION = os.environ.get('APP_VERSION', '1.0.0')
 
 # Logging configuration
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
+
+# Feature Flags
+# TESTING mode enables additional payment methods for testing (e.g., direct GCash)
+# Set to 'true' in development/staging environments
+TESTING = os.environ.get('TESTING', 'false').lower() == 'true'
 JSON_LOGGING = os.environ.get('JSON_LOGGING', 'false').lower() == 'true'
 
 # Rate limiting

--- a/apps/frontend_mobile/iayos_mobile/app/payments/deposit.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/payments/deposit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -24,17 +24,20 @@ import {
 } from "../../constants/theme";
 import {
   useWalletDeposit,
+  useWalletDepositGCash,
   useWalletBalance,
   formatCurrency,
   WalletDepositResponse,
 } from "../../lib/hooks/usePayments";
 import WalletBalanceCard from "../../components/WalletBalanceCard";
+import { ENDPOINTS } from "../../lib/api/config";
 
 /**
  * Wallet Deposit Screen
  *
- * Allows users to deposit funds to wallet via QR PH:
+ * Allows users to deposit funds to wallet via QR PH or GCash Direct (testing):
  * - Enter deposit amount
+ * - Select payment method (QR PH or GCash Direct in testing mode)
  * - Create PayMongo checkout session
  * - Display WebView for payment (QR code shown)
  * - Option to download/share QR code for mobile users
@@ -43,6 +46,9 @@ import WalletBalanceCard from "../../components/WalletBalanceCard";
  *
  * Route params: amount (optional)
  */
+
+// Payment method type
+type PaymentMethod = "qrph" | "gcash";
 
 export default function WalletDepositScreen() {
   const router = useRouter();
@@ -54,9 +60,31 @@ export default function WalletDepositScreen() {
   const [amountError, setAmountError] = useState<string | null>(null);
   const [pendingDeposit, setPendingDeposit] = useState<number | null>(null);
   const [webViewHandled, setWebViewHandled] = useState(false);
+  
+  // TODO: REMOVE FOR PROD - Testing mode for GCash direct
+  const [isTestingMode, setIsTestingMode] = useState(false);
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<PaymentMethod>("qrph");
 
   const { data: walletBalance, refetch: refetchBalance } = useWalletBalance();
   const depositMutation = useWalletDeposit();
+  // TODO: REMOVE FOR PROD - GCash direct deposit for testing
+  const depositGCashMutation = useWalletDepositGCash();
+
+  // Fetch config to check if testing mode is enabled
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await fetch(ENDPOINTS.MOBILE_CONFIG);
+        if (response.ok) {
+          const config = await response.json();
+          setIsTestingMode(config.testing === true);
+        }
+      } catch (error) {
+        console.log("Failed to fetch mobile config:", error);
+      }
+    };
+    fetchConfig();
+  }, []);
 
   // Preset amounts
   const presetAmounts = [100, 200, 500, 1000, 2000, 5000];
@@ -137,10 +165,17 @@ export default function WalletDepositScreen() {
 
     try {
       setIsProcessing(true);
-      // QR PH payment - no payment method selection needed
-      const response = await depositMutation.mutateAsync({
-        amount,
-      });
+      
+      // TODO: REMOVE FOR PROD - Use GCash direct in testing mode if selected
+      let response: WalletDepositResponse;
+      if (isTestingMode && selectedPaymentMethod === "gcash") {
+        // GCash Direct checkout - testing only
+        response = await depositGCashMutation.mutateAsync({ amount });
+      } else {
+        // QR PH payment - standard flow
+        response = await depositMutation.mutateAsync({ amount });
+      }
+      
       const invoiceUrl = getInvoiceUrl(response);
       setPendingDeposit(amount);
       setAmountError(null);
@@ -435,21 +470,104 @@ export default function WalletDepositScreen() {
           </View>
         </View>
 
-        {/* QR PH Payment Info */}
+        {/* TODO: REMOVE FOR PROD - Payment Method Selector (Testing Mode Only) */}
+        {isTestingMode && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Payment Method</Text>
+            <Text style={styles.sectionSubtitle}>
+              🧪 Testing Mode - Choose payment method
+            </Text>
+            
+            <View style={styles.paymentMethodContainer}>
+              <TouchableOpacity
+                style={[
+                  styles.paymentMethodButton,
+                  selectedPaymentMethod === "qrph" && styles.paymentMethodButtonActive,
+                ]}
+                onPress={() => setSelectedPaymentMethod("qrph")}
+              >
+                <Ionicons 
+                  name="qr-code" 
+                  size={24} 
+                  color={selectedPaymentMethod === "qrph" ? Colors.white : Colors.textPrimary} 
+                />
+                <Text style={[
+                  styles.paymentMethodText,
+                  selectedPaymentMethod === "qrph" && styles.paymentMethodTextActive,
+                ]}>
+                  QR PH
+                </Text>
+                <Text style={[
+                  styles.paymentMethodSubtext,
+                  selectedPaymentMethod === "qrph" && styles.paymentMethodSubtextActive,
+                ]}>
+                  Any banking app
+                </Text>
+              </TouchableOpacity>
+              
+              <TouchableOpacity
+                style={[
+                  styles.paymentMethodButton,
+                  selectedPaymentMethod === "gcash" && styles.paymentMethodButtonActive,
+                ]}
+                onPress={() => setSelectedPaymentMethod("gcash")}
+              >
+                <Ionicons 
+                  name="wallet" 
+                  size={24} 
+                  color={selectedPaymentMethod === "gcash" ? Colors.white : Colors.textPrimary} 
+                />
+                <Text style={[
+                  styles.paymentMethodText,
+                  selectedPaymentMethod === "gcash" && styles.paymentMethodTextActive,
+                ]}>
+                  GCash Direct
+                </Text>
+                <Text style={[
+                  styles.paymentMethodSubtext,
+                  selectedPaymentMethod === "gcash" && styles.paymentMethodSubtextActive,
+                ]}>
+                  Opens GCash app
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        )}
+
+        {/* Payment Info Card - Dynamic based on selected method */}
         <View style={styles.infoCard}>
           <View style={styles.infoHeader}>
-            <Ionicons name="qr-code" size={24} color={Colors.primary} />
-            <Text style={styles.infoTitle}>QR PH Payment</Text>
+            <Ionicons 
+              name={selectedPaymentMethod === "gcash" ? "wallet" : "qr-code"} 
+              size={24} 
+              color={Colors.primary} 
+            />
+            <Text style={styles.infoTitle}>
+              {selectedPaymentMethod === "gcash" ? "GCash Direct Payment" : "QR PH Payment"}
+            </Text>
           </View>
-          <Text style={styles.infoText}>
-            You'll be shown a QR code that you can scan with any Philippine
-            banking app (GCash, Maya, BPI, BDO, UnionBank, etc.) to complete
-            your deposit.
-          </Text>
-          <Text style={[styles.infoText, { marginTop: Spacing.sm }]}>
-            Since you're on your phone, you can save or share the QR code to
-            scan from another device.
-          </Text>
+          {selectedPaymentMethod === "gcash" ? (
+            <>
+              <Text style={styles.infoText}>
+                🧪 <Text style={{fontWeight: "600"}}>Testing Mode:</Text> You'll be redirected to GCash to complete your payment directly in the GCash app.
+              </Text>
+              <Text style={[styles.infoText, { marginTop: Spacing.sm, color: Colors.warning }]}>
+                ⚠️ This option is for testing only and will be removed in production.
+              </Text>
+            </>
+          ) : (
+            <>
+              <Text style={styles.infoText}>
+                You'll be shown a QR code that you can scan with any Philippine
+                banking app (GCash, Maya, BPI, BDO, UnionBank, etc.) to complete
+                your deposit.
+              </Text>
+              <Text style={[styles.infoText, { marginTop: Spacing.sm }]}>
+                Since you're on your phone, you can save or share the QR code to
+                scan from another device.
+              </Text>
+            </>
+          )}
         </View>
 
         {/* Deposit Button */}
@@ -690,5 +808,40 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.lg,
     fontWeight: Typography.fontWeight.semiBold as any,
     color: Colors.textPrimary,
+  },
+  // TODO: REMOVE FOR PROD - Payment method selector styles
+  paymentMethodContainer: {
+    flexDirection: "row",
+    gap: Spacing.md,
+  },
+  paymentMethodButton: {
+    flex: 1,
+    backgroundColor: Colors.white,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.lg,
+    alignItems: "center",
+    borderWidth: 2,
+    borderColor: Colors.border,
+    gap: Spacing.xs,
+  },
+  paymentMethodButtonActive: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  paymentMethodText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semiBold as any,
+    color: Colors.textPrimary,
+  },
+  paymentMethodTextActive: {
+    color: Colors.white,
+  },
+  paymentMethodSubtext: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+  },
+  paymentMethodSubtextActive: {
+    color: Colors.white,
+    opacity: 0.8,
   },
 });

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -427,6 +427,10 @@ export const ENDPOINTS = {
   WALLET_PENDING_EARNINGS: `${API_URL}/api/mobile/wallet/pending-earnings`,
   TRANSACTIONS: `${API_URL}/api/mobile/wallet/transactions`,
   DEPOSIT: `${API_URL}/api/mobile/wallet/deposit`,
+  // TODO: REMOVE FOR PROD - GCash direct deposit for testing
+  DEPOSIT_GCASH: `${API_URL}/api/mobile/wallet/deposit-gcash`,
+  // Mobile config endpoint (no auth required)
+  MOBILE_CONFIG: `${API_URL}/api/mobile/config`,
 
   // Phase 3: Escrow Payment System (10 endpoints)
   CREATE_ESCROW_PAYMENT: `${API_URL}/api/mobile/payments/escrow`,

--- a/apps/frontend_mobile/iayos_mobile/lib/hooks/usePayments.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/hooks/usePayments.ts
@@ -308,6 +308,49 @@ export const useWalletDeposit = () => {
   });
 };
 
+// TODO: REMOVE FOR PROD - GCash direct deposit for testing
+// Hook: Wallet deposit via GCash Direct (testing only)
+export const useWalletDepositGCash = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<WalletDepositResponse, Error, WalletDepositParams>({
+    mutationFn: async ({ amount }: WalletDepositParams) => {
+      return fetchJson<WalletDepositResponse>(ENDPOINTS.DEPOSIT_GCASH, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          amount,
+          payment_method: "GCASH",
+        }),
+      });
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["walletBalance"] });
+      queryClient.invalidateQueries({ queryKey: ["wallet"] });
+
+      Toast.show({
+        type: "success",
+        text1: "GCash Deposit Initiated (Testing)",
+        text2: data.payment_url
+          ? "Redirecting to GCash..."
+          : "Wallet balance updated",
+        position: "top",
+      });
+    },
+    onError: (error: Error) => {
+      Toast.show({
+        type: "error",
+        text1: "GCash Deposit Failed",
+        text2: error.message,
+        position: "top",
+      });
+    },
+  });
+};
+
 // Utility: Calculate escrow amount (50% of job budget + 10% platform fee on that 50%)
 // Worker receives full job budget, client pays platform fee on top
 export const calculateEscrowAmount = (jobBudget: number) => {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,9 @@ services:
     container_name: iayos-backend-dev
     env_file:
       - .env.docker
+    environment:
+      # TODO: REMOVE FOR PROD - Enable testing mode for GCash direct deposits
+      - TESTING=true
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
## Summary

This PR adds two major features:

### 1. GCash Direct Deposit (Testing Mode Only)
Problem: PayMongo QR PH shows a non-functional link in test mode.
Solution: Added GCash Direct Checkout as an alternative when testing.

### 2. Friday Auto-Withdrawal System
Problem: Workers and agencies need automated earnings withdrawal.
Solution: Platform-wide Friday payroll that creates PENDING withdrawal requests.

Auto-Withdrawal Rules:
- Runs every Friday at 10:00 AM PH time
- Minimum balance: P100.00 (hardcoded)
- Creates PENDING transactions (admin processes manually)
- Skips wallets without payment method and notifies user

## Testing

1. Set TESTING=true in environment
2. Open mobile deposit screen - should see payment method selector
3. Test auto-withdrawal: python manage.py process_auto_withdrawals --dry-run --verbose --force
