### PR TITLE
fix: Update fallback version to 1.9.0 when GitHub API fails

### DIFF
--- a/apps/backend/src/accounts/mobile_api.py
+++ b/apps/backend/src/accounts/mobile_api.py
@@ -3177,7 +3177,7 @@ def get_mobile_config(request):
     
     # Final defaults if still not set
     if not current_version:
-        current_version = '1.8.11'
+        current_version = '1.9.0'
     if not min_version:
         min_version = current_version  # Default: require latest version
     


### PR DESCRIPTION
The GitHub API fallback in /api/mobile/config is failing silently, causing the hardcoded fallback version 1.8.11 to be returned. Updated to 1.9.0 to match latest release.