### PR TITLE
fix: Remove version number from download page

### DIFF
--- a/apps/frontend_web/app/auth/download-app/page.tsx
+++ b/apps/frontend_web/app/auth/download-app/page.tsx
@@ -165,13 +165,7 @@ export default function DownloadAppPage() {
             </a>
 
             <p className="text-center text-sm text-gray-500">
-              {loading ? (
-                'Loading version...'
-              ) : error ? (
-                <span className="text-amber-600">v{release?.version || '?'} • Using fallback</span>
-              ) : (
-                <>v{release?.version} • Latest Release</>
-              )}
+              Latest Release
             </p>
           </div>
 


### PR DESCRIPTION
Since the download link always points to /releases/latest, we don't need to display the version number. This avoids sync issues between backend API and actual releases.