### PR TITLE
fix: Make location endpoints public for agency registration

### DIFF
--- a/apps/backend/src/accounts/mobile_api.py
+++ b/apps/backend/src/accounts/mobile_api.py
@@ -1480,10 +1480,10 @@ def mobile_remove_skill(request, skill_id: int):
         )
 
 
-@mobile_router.get("/locations/cities", auth=jwt_auth)
+@mobile_router.get("/locations/cities")
 def get_cities(request):
     """
-    Get all cities
+    Get all cities (public endpoint for registration)
     """
     from .models import City
     
@@ -1501,10 +1501,10 @@ def get_cities(request):
         )
 
 
-@mobile_router.get("/locations/cities/{city_id}/barangays", auth=jwt_auth)
+@mobile_router.get("/locations/cities/{city_id}/barangays")
 def get_barangays(request, city_id: int):
     """
-    Get all barangays for a specific city
+    Get all barangays for a specific city (public endpoint for registration)
     """
     from .models import Barangay
     


### PR DESCRIPTION
## Problem
The barangay dropdown on the agency registration page was showing empty because the \/api/mobile/locations/cities/{id}/barangays\ endpoint requires JWT authentication, but users are not logged in during registration.

## Solution
Remove JWT auth requirement from location endpoints:
- \GET /locations/cities\ - now public
- \GET /locations/cities/{id}/barangays\ - now public

These endpoints only return static location data (cities and barangays) and are needed for:
- Agency registration form
- User registration form
- Any address selection before login

## Changes
- Removed \uth=jwt_auth\ from both endpoints in \mobile_api.py\
- Updated docstrings to clarify they are public endpoints