### PR TITLE
fix: Job Requirements Display Bug (#205)

### DIFF
--- a/apps/backend/src/accounts/mobile_services.py
+++ b/apps/backend/src/accounts/mobile_services.py
@@ -692,10 +692,10 @@ def create_mobile_job(user: Accounts, job_data: Dict[str, Any]) -> Dict[str, Any
             status='PENDING_PAYMENT',  # Will change to ACTIVE after payment
             escrowAmount=escrow_amount,  # 50% held in escrow
             remainingPayment=escrow_amount,  # 50% remaining payment (no commission on final)
-            # Universal job fields for ML accuracy
-            job_scope=job_data.get('job_scope', 'MINOR_REPAIR'),
-            skill_level_required=job_data.get('skill_level_required', 'INTERMEDIATE'),
-            work_environment=job_data.get('work_environment', 'INDOOR'),
+            # Universal job fields for ML accuracy - use values from request (model has defaults if None)
+            job_scope=job_data.get('job_scope'),
+            skill_level_required=job_data.get('skill_level_required'),
+            work_environment=job_data.get('work_environment'),
         )
 
         # Handle payment based on method
@@ -971,10 +971,10 @@ def create_mobile_invite_job(user: Accounts, job_data: Dict[str, Any]) -> Dict[s
                     status="ACTIVE",  # Job created, awaiting acceptance
                     assignedAgencyFK=assigned_agency,
                     assignedWorkerID=assigned_worker,
-                    # Universal job fields for ML accuracy
-                    job_scope=job_data.get('job_scope', 'MINOR_REPAIR'),
-                    skill_level_required=job_data.get('skill_level_required', 'INTERMEDIATE'),
-                    work_environment=job_data.get('work_environment', 'INDOOR'),
+                    # Universal job fields for ML accuracy - use values from request (model has defaults if None)
+                    job_scope=job_data.get('job_scope'),
+                    skill_level_required=job_data.get('skill_level_required'),
+                    work_environment=job_data.get('work_environment'),
                 )
                 
                 # Create escrow transaction

--- a/apps/frontend_mobile/iayos_mobile/app/jobs/[id].tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/jobs/[id].tsx
@@ -314,10 +314,10 @@ export default function JobDetailScreen() {
             }
           : undefined,
         estimatedCompletion: jobData.estimated_completion || null,
-        // Universal job fields for ML
-        job_scope: jobData.job_scope || "MODERATE_PROJECT",
-        skill_level_required: jobData.skill_level_required || "INTERMEDIATE",
-        work_environment: jobData.work_environment || "INDOOR",
+        // Universal job fields for ML - use actual values from backend (no hardcoded fallbacks)
+        job_scope: jobData.job_scope,
+        skill_level_required: jobData.skill_level_required,
+        work_environment: jobData.work_environment,
         // Team Job fields
         is_team_job: jobData.is_team_job || false,
         skill_slots: jobData.skill_slots || [],

--- a/apps/frontend_mobile/iayos_mobile/app/jobs/create/index.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/jobs/create/index.tsx
@@ -71,13 +71,13 @@ interface CreateJobRequest {
   expected_duration?: string;
   urgency_level: "LOW" | "MEDIUM" | "HIGH";
   preferred_start_date?: string;
-  payment_method: "WALLET"; // Jobs only use Wallet payment (deposits via QR PH)
+  downpayment_method: "WALLET" | "GCASH"; // Payment method for job escrow
   worker_id?: number;
   agency_id?: number;
   // Universal job fields for ML accuracy
-  skill_level_required?: "ENTRY" | "INTERMEDIATE" | "EXPERT";
-  job_scope?: "MINOR_REPAIR" | "MODERATE_PROJECT" | "MAJOR_RENOVATION";
-  work_environment?: "INDOOR" | "OUTDOOR" | "BOTH";
+  skill_level_required: "ENTRY" | "INTERMEDIATE" | "EXPERT";
+  job_scope: "MINOR_REPAIR" | "MODERATE_PROJECT" | "MAJOR_RENOVATION";
+  work_environment: "INDOOR" | "OUTDOOR" | "BOTH";
 }
 
 export default function CreateJobScreen() {
@@ -412,8 +412,8 @@ export default function CreateJobScreen() {
       preferred_start_date: startDate
         ? startDate.toISOString().split("T")[0]
         : undefined,
-      payment_method: "WALLET", // Jobs only use Wallet payment
-      // Universal job fields for ML accuracy
+      downpayment_method: "WALLET", // Jobs only use Wallet payment
+      // Universal job fields for ML accuracy - explicitly passed
       skill_level_required: skillLevel,
       job_scope: jobScope,
       work_environment: workEnvironment,

--- a/apps/frontend_mobile/iayos_mobile/app/jobs/edit/[id].tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/jobs/edit/[id].tsx
@@ -153,7 +153,8 @@ export default function EditJobScreen() {
         urgency_level: data.urgency_level || "MEDIUM",
         preferred_start_date: data.preferred_start_date,
         materials_needed: data.materials_needed || [],
-        job_scope: data.job_scope || "MODERATE_PROJECT",
+        // Use model-consistent defaults if backend returns null
+        job_scope: data.job_scope || "MINOR_REPAIR",
         skill_level_required: data.skill_level_required || "INTERMEDIATE",
         work_environment: data.work_environment || "INDOOR",
         status: data.status,
@@ -191,7 +192,8 @@ export default function EditJobScreen() {
       }
 
       setMaterials(jobData.materials_needed || []);
-      setJobScope(jobData.job_scope || "MODERATE_PROJECT");
+      // Use model-consistent defaults
+      setJobScope(jobData.job_scope || "MINOR_REPAIR");
       setSkillLevel(jobData.skill_level_required || "INTERMEDIATE");
       setWorkEnvironment(jobData.work_environment || "INDOOR");
       setHasPendingApplications(jobData.has_pending_applications);

--- a/tests/test_job_requirements_fix.http
+++ b/tests/test_job_requirements_fix.http
@@ -1,0 +1,55 @@
+### Test Job Requirements Display Bug Fix (Issue #205)
+### This test verifies that job_scope, skill_level_required, and work_environment are saved correctly
+
+### Variables
+@baseUrl = http://localhost:8000
+@email = worker@example.com
+@password = password123
+
+### 1. Login to get token
+# @name login
+POST {{baseUrl}}/api/accounts/login
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "{{password}}"
+}
+
+### Store the token
+@token = {{login.response.body.access_token}}
+
+### 2. Create a job with SPECIFIC values (not defaults)
+### Expected: EXPERT, MAJOR_RENOVATION, OUTDOOR should be saved
+# @name createJob
+POST {{baseUrl}}/api/mobile/jobs/create
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "title": "Test Job Requirements Fix #205",
+  "description": "This test verifies that job_scope, skill_level_required, and work_environment are saved correctly instead of using hardcoded defaults. The user selected EXPERT, MAJOR_RENOVATION, and OUTDOOR.",
+  "category_id": 1,
+  "budget": 5000,
+  "location": "Test Street, Tetuan",
+  "expected_duration": "3 hours",
+  "urgency_level": "HIGH",
+  "downpayment_method": "WALLET",
+  "skill_level_required": "EXPERT",
+  "job_scope": "MAJOR_RENOVATION",
+  "work_environment": "OUTDOOR"
+}
+
+### Store the job ID
+@jobId = {{createJob.response.body.job_posting_id}}
+
+### 3. Get job details and verify the values are saved correctly
+### Expected: skill_level_required=EXPERT, job_scope=MAJOR_RENOVATION, work_environment=OUTDOOR
+# @name getJob
+GET {{baseUrl}}/api/mobile/jobs/{{jobId}}
+Authorization: Bearer {{token}}
+
+### Verification checklist:
+### - skill_level_required should be "EXPERT" (not "INTERMEDIATE")
+### - job_scope should be "MAJOR_RENOVATION" (not "MINOR_REPAIR")
+### - work_environment should be "OUTDOOR" (not "INDOOR")


### PR DESCRIPTION
## Summary

Fixes GitHub Issue #205 - Job Requirements displays inaccurate details.

## Problem

When creating a job with:
- **Skill Level**: Expert
- **Job Scope**: Moderate
- **Work Environment**: Outdoor

The Job Details screen incorrectly displayed:
- Minor Repair (instead of user's selection)
- Intermediate (instead of Expert)
- Indoor (instead of Outdoor)

## Root Causes Identified

1. **Field Name Mismatch**: Frontend sent \payment_method: 'WALLET'\ but backend expected \downpayment_method\
2. **Hardcoded Fallback Defaults**: Backend used \job_data.get('field', 'DEFAULT')\ which applied hardcoded defaults when keys weren't found
3. **Inconsistent Frontend Fallbacks**: Job detail screen had \|| 'MODERATE_PROJECT'\ while model default is \MINOR_REPAIR\

## Fixes Applied

### 1. Frontend Job Creation (\jobs/create/index.tsx\)
- Changed \payment_method\ → \downpayment_method\ to match backend schema
- Made \skill_level_required\, \job_scope\, \work_environment\ required (not optional)
- Values are now explicitly passed from form state

### 2. Backend Services (\mobile_services.py\)
- Removed hardcoded fallback defaults from both LISTING and INVITE job creation
- Changed from: \job_scope=job_data.get('job_scope', 'MINOR_REPAIR')\
- Changed to: \job_scope=job_data.get('job_scope')\
- Django model defaults apply only if value is \None\

### 3. Frontend Display (\jobs/[id].tsx\)
- Removed unnecessary fallback defaults in data transformation
- Now displays actual values from backend

### 4. Edit Screen (\jobs/edit/[id].tsx\)
- Aligned fallback defaults with Django model defaults for consistency

## Files Changed

| File | Changes |
|------|---------|
| \pps/frontend_mobile/.../jobs/create/index.tsx\ | Fix field name, make fields required |
| \pps/frontend_mobile/.../jobs/[id].tsx\ | Remove display fallbacks |
| \pps/frontend_mobile/.../jobs/edit/[id].tsx\ | Align fallback defaults |
| \pps/backend/src/accounts/mobile_services.py\ | Remove hardcoded defaults |
| \	ests/test_job_requirements_fix.http\ | API test for verification |

## Testing

✅ Schema validation passes with correct field names
✅ Values EXPERT, MAJOR_RENOVATION, OUTDOOR correctly accepted by backend
✅ TypeScript: 0 errors
✅ Backend container restarted successfully

Closes #205