### PR TITLE
feat: Add photo upload capability to agency mark complete modal

### DIFF
--- a/apps/frontend_web/lib/hooks/useAgencyConversations.ts
+++ b/apps/frontend_web/lib/hooks/useAgencyConversations.ts
@@ -280,6 +280,42 @@ export function useAgencyArchiveConversation() {
 }
 
 /**
+ * Upload a completion photo for a job (agency/worker action)
+ */
+export function useUploadCompletionPhoto() {
+  return useMutation({
+    mutationFn: async ({
+      jobId,
+      file,
+    }: {
+      jobId: number;
+      file: File;
+    }) => {
+      const formData = new FormData();
+      formData.append("image", file);
+
+      const response = await fetch(
+        `${API_BASE}/api/jobs/${jobId}/upload-completion-photo`,
+        {
+          method: "POST",
+          credentials: "include",
+          body: formData,
+        },
+      );
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(
+          getErrorMessage(error, `Failed to upload photo: ${response.statusText}`),
+        );
+      }
+
+      return response.json();
+    },
+  });
+}
+
+/**
  * Mark a job as complete (agency/worker action)
  */
 export function useAgencyMarkComplete() {


### PR DESCRIPTION
## Summary
This PR adds photo upload capability to the agency mark complete workflow, closing the gap between mobile worker UI and agency web UI.

## Changes

### Backend
- New endpoint: POST /api/jobs/{job_id}/upload-completion-photo
  - Allows workers and agencies to upload completion photos
  - Validates authorization (assigned worker or agency owner)
  - Uploads to Supabase with proper path structure
  - Creates JobPhoto record for each upload
  - Supports JPEG, PNG, WEBP up to 5MB

### Frontend (Agency Web)
- New hook: useUploadCompletionPhoto for sequential photo uploads
- Updated Mark Complete Modal:
  - Added file input with drag-drop style button
  - Support up to 10 photos (matching mobile app limit)
  - Photo preview grid with remove buttons
  - Upload progress bar during submission
  - Sequential upload before marking complete

## Testing
1. Navigate to agency messages page with an active job
2. Click Mark Complete button
3. Add photos via the new upload zone
4. Verify photos appear in preview grid
5. Click Confirm Complete and verify upload progress
6. Confirm job is marked complete with photos stored

Closes gap analysis finding: Agency photo upload on completion.