### PR TITLE
fix: backjobs route ordering, agency chat UI, signed URLs, and agency name

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -2162,7 +2162,14 @@ def upload_agency_chat_image(request, conversation_id: int):
                 raise Exception(f"Upload failed: {upload_response['error']}")
             
             # Get public URL (relative for local storage)
-            public_url = settings.STORAGE.storage().from_('iayos_files').get_public_url(storage_path)
+            # Get signed URL for private bucket (24 hour expiry)
+            signed_url_response = settings.STORAGE.storage().from_('iayos_files').create_signed_url(
+                storage_path, 
+                expires_in=86400  # 24 hours
+            )
+            if signed_url_response.get('error'):
+                raise Exception(f"Failed to create signed URL: {signed_url_response['error']}")
+            public_url = signed_url_response.get('signedURL')
             
             # Create IMAGE type message (from agency)
             message = Message.objects.create(

--- a/apps/backend/src/profiles/api.py
+++ b/apps/backend/src/profiles/api.py
@@ -1462,7 +1462,7 @@ def get_conversation_messages(request, conversation_id: int):
         
         # Build other_participant_info - handle agency case
         if other_participant:
-            other_participant_info = get_participant_info(other_participant, job.title)
+            other_participant_info = get_participant_info(profile=other_participant, job_title=job.title)
         elif other_agency:
             # Client viewing agency conversation - show agency info
             other_participant_info = {
@@ -2050,8 +2050,14 @@ def upload_chat_image(request, conversation_id: int, image: UploadedFile = File(
             if isinstance(upload_response, dict) and 'error' in upload_response:
                 raise Exception(f"Upload failed: {upload_response['error']}")
 
-            # Get public URL
-            public_url = settings.STORAGE.storage().from_('iayos_files').get_public_url(storage_path)
+            # Get signed URL for private bucket (24 hour expiry)
+            signed_url_response = settings.STORAGE.storage().from_('iayos_files').create_signed_url(
+                storage_path, 
+                expires_in=86400  # 24 hours
+            )
+            if signed_url_response.get('error'):
+                raise Exception(f"Failed to create signed URL: {signed_url_response['error']}")
+            public_url = signed_url_response.get('signedURL')
 
             # Create IMAGE type message
             message = Message.objects.create(

--- a/tests/test_my_backjobs_endpoint.http
+++ b/tests/test_my_backjobs_endpoint.http
@@ -1,0 +1,86 @@
+### Test my-backjobs endpoint (route ordering fix)
+### This test verifies that /api/jobs/my-backjobs is correctly matched
+### instead of being parsed as /api/jobs/{job_id} with "my-backjobs" as int
+
+### Variables
+@baseUrl = http://localhost:8000
+@workerEmail = worker@example.com
+@workerPassword = password123
+@agencyEmail = agency@example.com
+@agencyPassword = password123
+
+### ============================================
+### AUTHENTICATION - Get JWT Token
+### ============================================
+
+### Login as Worker
+# @name workerLogin
+POST {{baseUrl}}/api/accounts/login
+Content-Type: application/json
+
+{
+  "email": "{{workerEmail}}",
+  "password": "{{workerPassword}}"
+}
+
+### Store worker token
+@workerToken = {{workerLogin.response.body.access_token}}
+
+### Login as Agency
+# @name agencyLogin
+POST {{baseUrl}}/api/accounts/login
+Content-Type: application/json
+
+{
+  "email": "{{agencyEmail}}",
+  "password": "{{agencyPassword}}"
+}
+
+### Store agency token
+@agencyToken = {{agencyLogin.response.body.access_token}}
+
+### ============================================
+### MY-BACKJOBS ENDPOINT TESTS
+### ============================================
+
+### Test 1: Fetch my-backjobs as worker (should NOT return 422 int_parsing error)
+### EXPECTED: 200 OK with { backjobs: [], total: 0 } or actual backjobs data
+### PREVIOUSLY: 422 Unprocessable Entity (int_parsing error on "my-backjobs")
+GET {{baseUrl}}/api/jobs/my-backjobs
+Authorization: Bearer {{workerToken}}
+
+### Test 2: Fetch my-backjobs as agency
+### EXPECTED: 200 OK with agency's backjobs
+GET {{baseUrl}}/api/jobs/my-backjobs
+Authorization: Bearer {{agencyToken}}
+
+### Test 3: Fetch my-backjobs with status filter
+### EXPECTED: 200 OK with filtered backjobs
+GET {{baseUrl}}/api/jobs/my-backjobs?status=UNDER_REVIEW
+Authorization: Bearer {{workerToken}}
+
+### Test 4: Fetch my-backjobs without auth (should fail)
+### EXPECTED: 401 Unauthorized
+GET {{baseUrl}}/api/jobs/my-backjobs
+
+### ============================================
+### VERIFY REGULAR JOB_ID ROUTE STILL WORKS
+### ============================================
+
+### Test 5: Fetch job by ID (verify /{job_id} route still works)
+### Replace 1 with an actual job ID from your database
+### EXPECTED: 200 OK with job details or 404 if not found
+GET {{baseUrl}}/api/jobs/1
+Cookie: sessionid=your_session_cookie_here
+
+### ============================================
+### ROUTE ORDERING VERIFICATION
+### ============================================
+
+### Test 6: This should NOT match /{job_id} route
+### The string "my-backjobs" should match the literal route, not be parsed as int
+### If this returns 422 with int_parsing error, the fix failed
+GET {{baseUrl}}/api/jobs/my-backjobs
+Authorization: Bearer {{workerToken}}
+# Expected: 200 OK
+# NOT Expected: {"detail": [{"type": "int_parsing", "loc": ["path", "job_id"]}]}


### PR DESCRIPTION
## Summary

Fixes 3 issues affecting backjob functionality and chat UX.

### Section 1: Backend my-backjobs Route Ordering Bug
**Problem**: Route \/api/jobs/my-backjobs\ was defined AFTER \/api/jobs/{job_id}\, so 'my-backjobs' was being parsed as an integer job_id, causing \int_parsing\ error.

**Fix**: 
- Moved \/my-backjobs\ endpoint BEFORE \/{job_id}\ route in jobs/api.py
- Added warning comment to prevent future regressions

### Section 2: Signed URLs for Private Bucket
**Problem**: Code was using \get_public_url()\ which generates broken URLs for private buckets.

**Fix**:
- Changed to \create_signed_url()\ with 24-hour expiry in:
  - profiles/api.py (chat image upload)
  - agency/api.py (agency chat image upload)
  - jobs/api.py (dispute evidence upload)

### Section 3: Agency Chat - SYSTEM Message Rendering
**Problem**: Mobile shows centered SYSTEM messages for backjob initiation, but agency web chat lacked this rendering.

**Fix**:
- Added conditional check for \message.message_type === 'SYSTEM'\
- Created centered system message UI with gray pill styling
- Matches mobile app MessageBubble pattern

### Section 4: Agency Name Showing 'Unknown' Fix
**Problem**: \get_participant_info()\ was called with wrong positional args - job.title was being passed as the \gency\ parameter.

**Fix**:
- Changed to use named parameters: \get_participant_info(profile=other_participant, job_title=job.title)\

## Files Changed
- \pps/backend/src/jobs/api.py\ - Route ordering + signed URLs
- \pps/backend/src/profiles/api.py\ - Signed URLs + get_participant_info fix
- \pps/backend/src/agency/api.py\ - Signed URLs  
- \pps/frontend_web/app/agency/messages/[id]/page.tsx\ - SYSTEM message UI
- \	ests/test_my_backjobs_endpoint.http\ - New test file

## Testing
- Test \/api/jobs/my-backjobs\ endpoint returns 200 instead of 422
- Test chat image uploads work with signed URLs
- Test agency chat shows centered SYSTEM messages
- Test agency name displays correctly (not 'Unknown')