### PR TITLE
fix: use centralized API_BASE config in agency sidebar

### DIFF
--- a/apps/frontend_web/app/agency/components/sidebar.tsx
+++ b/apps/frontend_web/app/agency/components/sidebar.tsx
@@ -24,8 +24,7 @@ import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/context/AuthContext";
 import { useNotifications } from "@/context/NotificationContext";
-
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
+import { API_BASE } from "@/lib/api/config";
 
 export default function AgencySidebar({ className }: { className?: string }) {
   const pathname = usePathname();


### PR DESCRIPTION
## Problem
Agency sidebar was making API requests to \localhost:8000\ in production because it defined its own local \API_BASE\ variable using \NEXT_PUBLIC_BACKEND_URL\ (a non-standard env var) with localhost fallback.

## Solution
- Remove hardcoded \const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'\
- Import \API_BASE\ from \@/lib/api/config\ which already handles production/development environments correctly

## Impact
Fixes production agency sidebar calling \localhost:8000\ instead of \pi.iayos.online\ for backjobs count badge.

## Testing
- Verify network tab shows requests to \https://api.iayos.online/api/jobs/my-backjobs\ in production
- Verify backjobs count badge still loads correctly