### PR TITLE
fix: chat images and backjobs auth issues

### DIFF
--- a/apps/backend/src/jobs/api.py
+++ b/apps/backend/src/jobs/api.py
@@ -1433,7 +1433,7 @@ def get_my_applications(request):
 
 # NOTE: This route MUST be defined BEFORE /{job_id} to avoid route matching conflict!
 # Otherwise "my-backjobs" gets parsed as a job_id integer and fails.
-@router.get("/my-backjobs", auth=jwt_auth)
+@router.get("/my-backjobs", auth=dual_auth)
 def get_my_backjobs(request, status: Optional[str] = None):
     """
     Get backjobs assigned to the current worker or agency.

--- a/apps/backend/src/profiles/migrations/0009_increase_attachment_fileurl_length.py
+++ b/apps/backend/src/profiles/migrations/0009_increase_attachment_fileurl_length.py
@@ -1,0 +1,18 @@
+# Generated migration for increasing MessageAttachment.fileURL length
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0008_remove_conversation_conv_type_status_idx_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='messageattachment',
+            name='fileURL',
+            field=models.CharField(max_length=1024),
+        ),
+    ]

--- a/apps/backend/src/profiles/models.py
+++ b/apps/backend/src/profiles/models.py
@@ -511,7 +511,8 @@ class MessageAttachment(models.Model):
         related_name='attachments'
     )
     
-    fileURL = models.CharField(max_length=255)
+    # Increased from 255 to 1024 to support signed URLs with tokens
+    fileURL = models.CharField(max_length=1024)
     fileName = models.CharField(max_length=255, null=True, blank=True)
     fileSize = models.IntegerField(null=True, blank=True)  # Size in bytes
     fileType = models.CharField(max_length=50, null=True, blank=True)  # MIME type


### PR DESCRIPTION
Fixes 401 on my-backjobs (jwt_auth to dual_auth), chat images not loading (store path not signed URL), and varchar too long error (255 to 1024)