### PR TITLE
feat: Add 3 missing agency endpoints + fix transaction display colors

### DIFF
--- a/apps/frontend_web/app/agency/profile/page.tsx
+++ b/apps/frontend_web/app/agency/profile/page.tsx
@@ -522,7 +522,7 @@ export default function AgencyProfilePage() {
                     {transactions
                       .filter(
                         (t: Transaction) =>
-                          t.type === "DEPOSIT" || t.type === "PAYMENT_RECEIVED",
+                          ["DEPOSIT", "EARNING", "PENDING_EARNING", "REFUND"].includes(t.type),
                       )
                       .reduce(
                         (sum: number, t: Transaction) => sum + t.amount,

--- a/apps/frontend_web/app/agency/transactions/page.tsx
+++ b/apps/frontend_web/app/agency/transactions/page.tsx
@@ -34,7 +34,7 @@ interface AgencyTransaction {
   balance_after?: number;
 }
 
-type TransactionFilter = "all" | "DEPOSIT" | "WITHDRAWAL" | "PAYMENT" | "PAYMENT_RECEIVED";
+type TransactionFilter = "all" | "DEPOSIT" | "WITHDRAWAL" | "PAYMENT" | "EARNING" | "PENDING_EARNING" | "REFUND" | "FEE";
 type StatusFilter = "all" | "COMPLETED" | "PENDING" | "FAILED";
 
 export default function AgencyTransactionsPage() {
@@ -94,13 +94,19 @@ export default function AgencyTransactionsPage() {
     toast.success("Transactions refreshed");
   };
 
+  // For agencies, incoming money types: EARNING, PENDING_EARNING, DEPOSIT, REFUND
+  const isIncomingType = (type: string) => 
+    ["DEPOSIT", "EARNING", "PENDING_EARNING", "REFUND"].includes(type);
+
   const getTransactionIcon = (type: string) => {
+    if (isIncomingType(type)) {
+      return <ArrowDownLeft className="h-5 w-5 text-green-600" />;
+    }
     switch (type) {
       case "WITHDRAWAL":
+      case "PAYMENT":
+      case "FEE":
         return <ArrowUpRight className="h-5 w-5 text-red-600" />;
-      case "DEPOSIT":
-      case "PAYMENT_RECEIVED":
-        return <ArrowDownLeft className="h-5 w-5 text-green-600" />;
       default:
         return <Wallet className="h-5 w-5 text-gray-600" />;
     }
@@ -153,16 +159,34 @@ export default function AgencyTransactionsPage() {
             Deposit
           </span>
         );
-      case "PAYMENT_RECEIVED":
+      case "EARNING":
+        return (
+          <span className="px-2 py-1 bg-green-50 text-green-600 rounded text-xs font-medium">
+            Earning
+          </span>
+        );
+      case "PENDING_EARNING":
+        return (
+          <span className="px-2 py-1 bg-yellow-50 text-yellow-600 rounded text-xs font-medium">
+            Pending Earning
+          </span>
+        );
+      case "REFUND":
         return (
           <span className="px-2 py-1 bg-blue-50 text-blue-600 rounded text-xs font-medium">
-            Payment Received
+            Refund
           </span>
         );
       case "PAYMENT":
         return (
           <span className="px-2 py-1 bg-purple-50 text-purple-600 rounded text-xs font-medium">
             Payment
+          </span>
+        );
+      case "FEE":
+        return (
+          <span className="px-2 py-1 bg-gray-50 text-gray-600 rounded text-xs font-medium">
+            Platform Fee
           </span>
         );
       default:
@@ -175,8 +199,9 @@ export default function AgencyTransactionsPage() {
   };
 
   // Calculate summary stats
+  // For agencies: DEPOSIT, EARNING, PENDING_EARNING, REFUND are incoming
   const totalDeposits = transactions
-    .filter((t: AgencyTransaction) => t.type === "DEPOSIT" || t.type === "PAYMENT_RECEIVED")
+    .filter((t: AgencyTransaction) => ["DEPOSIT", "EARNING", "PENDING_EARNING", "REFUND"].includes(t.type))
     .filter((t: AgencyTransaction) => t.status === "COMPLETED")
     .reduce((sum: number, t: AgencyTransaction) => sum + t.amount, 0);
 
@@ -294,8 +319,11 @@ export default function AgencyTransactionsPage() {
                   <option value="all">All Types</option>
                   <option value="DEPOSIT">Deposits</option>
                   <option value="WITHDRAWAL">Withdrawals</option>
-                  <option value="PAYMENT_RECEIVED">Payments Received</option>
+                  <option value="EARNING">Earnings</option>
+                  <option value="PENDING_EARNING">Pending Earnings</option>
+                  <option value="REFUND">Refunds</option>
                   <option value="PAYMENT">Payments Made</option>
+                  <option value="FEE">Platform Fees</option>
                 </select>
               </div>
 

--- a/apps/frontend_web/app/agency/wallet/page.tsx
+++ b/apps/frontend_web/app/agency/wallet/page.tsx
@@ -185,7 +185,7 @@ export default function AgencyWalletPage() {
                   <p className="text-2xl font-bold text-gray-900">
                     {formatCurrency(
                       transactions
-                        .filter((t: any) => t.type === "PAYMENT_RECEIVED")
+                        .filter((t: any) => ["EARNING", "PENDING_EARNING", "DEPOSIT", "REFUND"].includes(t.type))
                         .reduce((sum: number, t: any) => sum + t.amount, 0)
                     )}
                   </p>
@@ -322,50 +322,50 @@ export default function AgencyWalletPage() {
                   </div>
                 ) : (
                   <div className="space-y-3">
-                    {recentTransactions.map((tx: any) => (
-                      <div
-                        key={tx.id}
-                        className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 transition-colors"
-                      >
-                        <div className="flex items-center gap-3">
-                          <div
-                            className={`p-2 rounded-lg ${
-                              tx.type === "DEPOSIT" || tx.type === "PAYMENT_RECEIVED"
-                                ? "bg-green-100"
-                                : "bg-red-100"
+                    {recentTransactions.map((tx: any) => {
+                      // For agencies, incoming money types: EARNING, PENDING_EARNING, DEPOSIT, REFUND
+                      // Outgoing money types: WITHDRAWAL, PAYMENT, FEE
+                      const isIncoming = ["DEPOSIT", "EARNING", "PENDING_EARNING", "REFUND"].includes(tx.type);
+                      
+                      return (
+                        <div
+                          key={tx.id}
+                          className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 transition-colors"
+                        >
+                          <div className="flex items-center gap-3">
+                            <div
+                              className={`p-2 rounded-lg ${
+                                isIncoming
+                                  ? "bg-green-100"
+                                  : "bg-red-100"
+                              }`}
+                            >
+                              {isIncoming ? (
+                                <ArrowDownLeft className="h-4 w-4 text-green-600" />
+                              ) : (
+                                <ArrowUpRight className="h-4 w-4 text-red-600" />
+                              )}
+                            </div>
+                            <div>
+                              <p className="font-medium text-sm text-gray-900">{tx.description}</p>
+                              <p className="text-xs text-gray-400">
+                                {formatDistanceToNow(new Date(tx.created_at), { addSuffix: true })}
+                              </p>
+                            </div>
+                          </div>
+                          <p
+                            className={`font-semibold ${
+                              isIncoming
+                                ? "text-green-600"
+                                : "text-red-600"
                             }`}
                           >
-                            {tx.type === "DEPOSIT" || tx.type === "PAYMENT_RECEIVED" ? (
-                              <ArrowDownLeft
-                                className={`h-4 w-4 ${
-                                  tx.type === "DEPOSIT" || tx.type === "PAYMENT_RECEIVED"
-                                    ? "text-green-600"
-                                    : "text-red-600"
-                                }`}
-                              />
-                            ) : (
-                              <ArrowUpRight className="h-4 w-4 text-red-600" />
-                            )}
-                          </div>
-                          <div>
-                            <p className="font-medium text-sm text-gray-900">{tx.description}</p>
-                            <p className="text-xs text-gray-400">
-                              {formatDistanceToNow(new Date(tx.created_at), { addSuffix: true })}
-                            </p>
-                          </div>
+                            {isIncoming ? "+" : "-"}
+                            {formatCurrency(tx.amount)}
+                          </p>
                         </div>
-                        <p
-                          className={`font-semibold ${
-                            tx.type === "DEPOSIT" || tx.type === "PAYMENT_RECEIVED"
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }`}
-                        >
-                          {tx.type === "DEPOSIT" || tx.type === "PAYMENT_RECEIVED" ? "+" : "-"}
-                          {formatCurrency(tx.amount)}
-                        </p>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 )}
               </CardContent>


### PR DESCRIPTION
## Summary

Implements 3 missing backend endpoints discovered during agency UI deep scan + fixes transaction color display issue.

### Backend Endpoints Added

1. **GET /api/agency/wallet/pending-earnings**
   - Lists pending payments held in 7-day buffer period
   - Returns total pending, count, buffer days, and item details

2. **POST /api/agency/change-password**
   - Allows agency users to change their password
   - Validates current password, enforces strength requirements

3. **POST /api/agency/reviews/{id}/respond**
   - Allows agencies to respond to customer reviews
   - Validates agency/employee ownership of the review
   - Prevents duplicate responses (one per review)

### Frontend Fixes

**Transaction Color Display**
- Fixed issue where incoming payments (PENDING_EARNING, EARNING) were showing in red
- For agencies, these transaction types are now green (incoming):
  - DEPOSIT, EARNING, PENDING_EARNING, REFUND
- These remain red (outgoing): WITHDRAWAL, PAYMENT, FEE

**Files Modified:**
- agency/wallet/page.tsx - Recent transactions + Total Earned stat
- agency/transactions/page.tsx - Filter dropdown + icons + type badges
- agency/profile/page.tsx - Total Earnings calculation

## Testing
- Backend endpoints can be tested via .http file or Postman
- Frontend color display fixed for pending earnings (see attached image in issue)