### PR TITLE
feat: Portfolio dual_auth + Xendit cleanup

### DIFF
--- a/apps/backend/src/accounts/payment_provider.py
+++ b/apps/backend/src/accounts/payment_provider.py
@@ -2,18 +2,18 @@
 Payment Provider Abstraction Layer
 ===================================
 Provides a unified interface for payment gateway operations.
-Currently supports: PayMongo (primary), Xendit (legacy)
+
+Primary Provider: PayMongo
+Deprecated: Xendit (kept for legacy webhook handling only)
+
+NOTE: As of February 2026, PayMongo is the only active payment provider.
+Xendit support is deprecated and maintained only for processing historical
+transaction webhooks. Do not use Xendit for new transactions.
 
 This abstraction allows:
-1. Easy switching between payment providers via config
-2. Consistent API across all payment flows
-3. Clean separation of payment logic from business logic
-4. Graceful migration from Xendit to PayMongo
-
-Configuration:
-    Set PAYMENT_PROVIDER in settings.py or .env:
-    - "paymongo" (default, recommended)
-    - "xendit" (legacy, for rollback)
+1. Consistent API across all payment flows
+2. Clean separation of payment logic from business logic
+3. Legacy webhook handling for historical Xendit transactions
 """
 
 from abc import ABC, abstractmethod
@@ -170,22 +170,14 @@ class PaymentProviderInterface(ABC):
 
 def get_payment_provider() -> PaymentProviderInterface:
     """
-    Factory function to get the configured payment provider.
+    Factory function to get the payment provider.
     
-    Reads PAYMENT_PROVIDER from settings, defaults to 'paymongo'.
+    Returns PayMongo as the only active provider.
+    Xendit is deprecated and only used for legacy webhook processing.
     """
-    provider_name = getattr(settings, 'PAYMENT_PROVIDER', 'paymongo').lower()
-    
-    if provider_name == 'paymongo':
-        from .paymongo_service import PayMongoService
-        return PayMongoService()
-    elif provider_name == 'xendit':
-        from .xendit_provider import XenditProvider
-        return XenditProvider()
-    else:
-        logger.warning(f"Unknown payment provider '{provider_name}', falling back to PayMongo")
-        from .paymongo_service import PayMongoService
-        return PayMongoService()
+    # Always use PayMongo for new transactions
+    from .paymongo_service import PayMongoService
+    return PayMongoService()
 
 
 # Status mapping constants for consistent status handling

--- a/apps/backend/src/accounts/xendit_provider.py
+++ b/apps/backend/src/accounts/xendit_provider.py
@@ -1,11 +1,14 @@
-"""
-Xendit Payment Provider Adapter
-===============================
-Wraps existing XenditService to implement PaymentProviderInterface.
-Allows seamless switching between PayMongo and Xendit via config.
+\"\"\"
+[DEPRECATED] Xendit Payment Provider Adapter
+=============================================
+This adapter is DEPRECATED as of February 2026.
+PayMongo is now the only active payment provider.
 
-This is a thin adapter that delegates to the existing XenditService.
-"""
+This file is kept ONLY for backward compatibility.
+Do not use for new transactions.
+
+Wraps existing XenditService to implement PaymentProviderInterface.
+\"\"\"
 
 from typing import Dict, Any, Optional, List
 import logging

--- a/apps/backend/src/accounts/xendit_service.py
+++ b/apps/backend/src/accounts/xendit_service.py
@@ -1,12 +1,20 @@
-"""
-Xendit Payment Gateway Service
-Handles payment processing via Xendit API using direct HTTP requests
+\"\"\"
+[DEPRECATED] Xendit Payment Gateway Service
+============================================
+This service is DEPRECATED as of February 2026.
+PayMongo is now the primary payment provider.
 
-Circuit breaker pattern implemented for fault tolerance:
-- Opens after 5 consecutive failures
-- Recovers after 60 seconds
-- Prevents cascading failures during Xendit outages
-"""
+This file is kept ONLY for:
+1. Processing webhooks from historical Xendit transactions
+2. Checking status of legacy Xendit payments
+
+DO NOT use this service for new transactions.
+Use payment_provider.get_payment_provider() instead.
+
+Legacy features:
+- Handles payment processing via Xendit API using direct HTTP requests
+- Circuit breaker pattern implemented for fault tolerance
+\"\"\"
 
 import requests
 from django.conf import settings

--- a/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/api/config.ts
@@ -443,9 +443,8 @@ export const ENDPOINTS = {
 
   // Phase 3: Escrow Payment System (10 endpoints)
   CREATE_ESCROW_PAYMENT: `${API_URL}/api/mobile/payments/escrow`,
-  // Create payment invoice (generic name, same endpoint)
-  CREATE_PAYMENT_INVOICE: `${API_URL}/api/mobile/payments/xendit/invoice`,
-  CREATE_XENDIT_INVOICE: `${API_URL}/api/mobile/payments/xendit/invoice`, // Alias for backward compatibility
+  // Create payment invoice via wallet deposit flow (PayMongo)
+  CREATE_PAYMENT_INVOICE: `${API_URL}/api/mobile/wallet/deposit`,
   UPLOAD_CASH_PROOF: `${API_URL}/api/mobile/payments/cash-proof`,
   PAYMENT_STATUS: (id: number) => `${API_URL}/api/mobile/payments/status/${id}`,
   PAYMENT_HISTORY: `${API_URL}/api/mobile/payments/history`,
@@ -454,9 +453,8 @@ export const ENDPOINTS = {
   WALLET_TRANSACTIONS: `${API_URL}/api/mobile/wallet/transactions`,
   CREATE_JOB_WITH_PAYMENT: `${API_URL}/api/jobs/create-mobile`, // Direct worker/agency hiring
   CREATE_JOB: `${API_URL}/api/jobs/create-mobile`, // Direct worker/agency hiring
-  // Payment webhooks
+  // Payment webhooks (server-side only, not called from frontend)
   PAYMENT_WEBHOOK: `${API_URL}/api/accounts/wallet/paymongo-webhook`,
-  XENDIT_WEBHOOK: `${API_URL}/api/payments/xendit/callback`, // Legacy
   PAYMENT_RECEIPT: (id: number) =>
     `${API_URL}/api/mobile/payments/receipt/${id}`,
 

--- a/apps/frontend_mobile/iayos_mobile/lib/hooks/usePayments.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/hooks/usePayments.ts
@@ -47,15 +47,15 @@ export interface Transaction {
   paymentMethod?: string;
 }
 
-export interface XenditInvoice {
+export interface PaymentInvoice {
   invoiceUrl: string;
   invoiceId: string;
   expiryDate: string;
   amount: number;
 }
 
-// Alias for generic naming
-export type PaymentInvoice = XenditInvoice;
+// Legacy alias for backward compatibility
+export type XenditInvoice = PaymentInvoice;
 
 export interface WalletDepositResponse {
   success: boolean;
@@ -122,12 +122,11 @@ export const useCreateEscrowPayment = () => {
   });
 };
 
-// Hook: Create payment invoice (generic name)
-// Supports both PayMongo and Xendit via backend abstraction
+// Hook: Create payment invoice via PayMongo
 export const useCreatePaymentInvoice = () => {
   return useMutation({
     mutationFn: async (data: { jobId: number; amount: number }) => {
-      return fetchJson<PaymentInvoice>(ENDPOINTS.CREATE_PAYMENT_INVOICE || ENDPOINTS.CREATE_XENDIT_INVOICE, {
+      return fetchJson<PaymentInvoice>(ENDPOINTS.CREATE_PAYMENT_INVOICE, {
         method: "POST",
         credentials: "include",
         headers: {
@@ -147,29 +146,9 @@ export const useCreatePaymentInvoice = () => {
   });
 };
 
-// Hook: Create Xendit invoice for GCash payment (legacy alias)
-export const useCreateXenditInvoice = () => {
-  return useMutation({
-    mutationFn: async (data: { jobId: number; amount: number }) => {
-      return fetchJson<XenditInvoice>(ENDPOINTS.CREATE_XENDIT_INVOICE, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
-    },
-    onError: (error: Error) => {
-      Toast.show({
-        type: "error",
-        text1: "Invoice Creation Failed",
-        text2: error.message,
-        position: "top",
-      });
-    },
-  });
-};
+// Legacy alias - use useCreatePaymentInvoice instead
+/** @deprecated Use useCreatePaymentInvoice instead */
+export const useCreateXenditInvoice = useCreatePaymentInvoice;
 
 // Hook: Upload cash payment proof
 export const useUploadCashProof = () => {

--- a/apps/frontend_web/app/agency/profile/page.tsx
+++ b/apps/frontend_web/app/agency/profile/page.tsx
@@ -1143,7 +1143,7 @@ export default function AgencyProfilePage() {
 
                   setIsWithdrawing(true);
                   try {
-                    // Use agency-specific withdrawal endpoint (with Xendit)
+                    // Use agency-specific withdrawal endpoint
                     const res = await fetch(
                       `${API_BASE}/api/agency/wallet/withdraw`,
                       {

--- a/apps/frontend_web/app/dashboard/inbox/page.tsx
+++ b/apps/frontend_web/app/dashboard/inbox/page.tsx
@@ -554,7 +554,7 @@ const InboxPage = () => {
           // Check if payment is required
           if (data.requires_payment) {
             if (data.invoice_url) {
-              // GCASH payment - redirect to Xendit
+              // GCASH payment - redirect to payment gateway
               alert(`${data.message}\n\nRedirecting to payment page...`);
               window.location.href = data.invoice_url;
               setIsApprovingCompletion(false);
@@ -679,7 +679,7 @@ const InboxPage = () => {
     );
   };
 
-  // Handle confirming final payment after returning from Xendit
+  // Handle confirming final payment after returning from payment gateway
   const handleConfirmFinalPayment = async () => {
     if (!selectedChat) return;
 
@@ -1460,7 +1460,7 @@ const InboxPage = () => {
                           Confirm Payment Completed
                         </button>
                         <p className="text-xs text-gray-500 text-center mt-2">
-                          Click this after completing payment via Xendit
+                          Click this after completing payment via GCash
                         </p>
                       </div>
                     )}

--- a/apps/frontend_web/app/dashboard/myRequests/page.tsx
+++ b/apps/frontend_web/app/dashboard/myRequests/page.tsx
@@ -445,7 +445,7 @@ const MyRequestsPage = () => {
       if (response.ok && data.success) {
         const jobId = data.job_posting_id;
 
-        // Handle GCASH payment (requires Xendit)
+        // Handle GCASH payment (requires payment gateway)
         if (
           data.payment_method === "GCASH" &&
           data.requires_payment &&
@@ -459,7 +459,7 @@ const MyRequestsPage = () => {
               `Your job will be activated once payment is confirmed.`,
           );
 
-          // Open Xendit payment page
+          // Open payment page
           window.location.href = data.invoice_url;
           return;
         }
@@ -614,7 +614,7 @@ const MyRequestsPage = () => {
       if (response.ok && data.success) {
         const jobId = data.job_posting_id;
 
-        // Check if payment is required (Xendit invoice generated)
+        // Check if payment is required (payment invoice generated)
         if (data.requires_payment && data.invoice_url) {
           alert(
             `💰 Job Created - Payment Required\n\n` +
@@ -624,7 +624,7 @@ const MyRequestsPage = () => {
               `Your job will be activated once payment is confirmed.`,
           );
 
-          // Open Xendit payment page
+          // Open payment page
           window.location.href = data.invoice_url;
           return;
         }


### PR DESCRIPTION
## Summary

This PR adds mobile support for portfolio endpoints and cleans up deprecated Xendit references after the PayMongo migration.

### Section 1: Portfolio CRUD Mobile Support
- Changed 5 portfolio endpoints from cookie_auth to dual_auth
- POST/GET/PUT/DELETE /worker/portfolio/* now work with JWT tokens from mobile

### Section 3: Xendit Frontend Cleanup
- Removed CREATE_XENDIT_INVOICE from config.ts
- Removed XENDIT_WEBHOOK from config.ts  
- Updated CREATE_PAYMENT_INVOICE to use wallet deposit flow
- Deprecated useCreateXenditInvoice hook (aliased to useCreatePaymentInvoice)
- Renamed XenditInvoice interface to PaymentInvoice

### Section 4: Xendit Backend Deprecation
- Updated payment_provider.py to only return PayMongo
- Added deprecation headers to xendit_service.py and xendit_provider.py
- Updated check_payment_status to use payment provider abstraction
- Added deprecation note to xendit_webhook endpoint
- Updated web frontend comments from Xendit to payment gateway/GCash