### PR TITLE
Fix backjob chat activation bug + add agency notification

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -1993,6 +1993,13 @@ def send_agency_message(request, conversation_id: int, payload: schemas.AgencySe
         if not has_access:
             return Response({"error": "Access denied"}, status=403)
         
+        # Block sending messages if conversation is COMPLETED (not yet reopened for backjob)
+        if conv.status == Conversation.ConversationStatus.COMPLETED:
+            return Response({
+                "error": "This conversation is closed. Messages can only be sent after admin approves a backjob request.",
+                "conversation_status": "COMPLETED"
+            }, status=400)
+        
         # Create message - use senderAgency for agency users without profile
         message = Message.objects.create(
             conversationID=conv,

--- a/apps/backend/src/jobs/api.py
+++ b/apps/backend/src/jobs/api.py
@@ -5042,6 +5042,34 @@ def request_backjob(request, job_id: int, reason: str = Form(...), description: 
             print(f"📢 New backjob request created: Dispute #{dispute.disputeID} for Job #{job.jobID}")
             
             # ============================================================
+            # NOTIFY WORKER/AGENCY: Alert them about backjob request
+            # ============================================================
+            from accounts.models import Notification
+            
+            # Notify assigned worker if exists (individual job)
+            if job.assignedWorkerID:
+                Notification.objects.create(
+                    accountFK=job.assignedWorkerID.profileID.accountFK,
+                    notificationType="BACKJOB_REQUESTED",
+                    title="Backjob Request Received",
+                    message=f"📋 Client has requested a backjob for '{job.title}'. Admin is reviewing the request. Payment is on hold pending review.",
+                    relatedJobID=job.jobID
+                )
+                print(f"📬 Notified worker {job.assignedWorkerID.profileID.accountFK.email} about backjob request")
+            
+            # Notify assigned agency if exists
+            if job.assignedAgencyFK:
+                Notification.objects.create(
+                    accountFK=job.assignedAgencyFK.accountFK,
+                    notificationType="BACKJOB_REQUESTED",
+                    title="Backjob Request Received",
+                    message=f"📋 Client has requested a backjob for '{job.title}'. Admin is reviewing the request. Payment is on hold pending review.",
+                    relatedJobID=job.jobID
+                )
+                print(f"📬 Notified agency {job.assignedAgencyFK.businessName} about backjob request")
+            # ============================================================
+            
+            # ============================================================
             # HOLD PAYMENT: Put payment on hold due to backjob request
             # ============================================================
             hold_payment_for_backjob(job)


### PR DESCRIPTION
## Summary
Fixes two bugs in the backjob workflow:

### Bug 1: Chat activated before admin approval
**Problem**: Agencies could send messages in conversations even when the conversation status was COMPLETED (job finished but backjob not yet approved).

**Fix**: Added status check in \send_agency_message\ endpoint - returns 400 error if conversation is COMPLETED.

**File**: [agency/api.py](apps/backend/src/agency/api.py)

### Bug 2: Agency not notified when backjob requested
**Problem**: When a client requests a backjob, the \BACKJOB_REQUESTED\ notification type existed in the model but was never used. Workers/agencies only found out when admin approved.

**Fix**: Added notification creation in \equest_backjob\ endpoint for both individual workers and agencies.

**File**: [jobs/api.py](apps/backend/src/jobs/api.py)

## Testing
- Python syntax verified
- Notification uses existing \BACKJOB_REQUESTED\ type from Notification model