### PR TITLE
fix: correct Agency field names in receipt endpoint

### DIFF
--- a/apps/backend/src/jobs/api.py
+++ b/apps/backend/src/jobs/api.py
@@ -5973,8 +5973,8 @@ def get_job_receipt(request, job_id: int):
                 'type': 'AGENCY',
                 'id': agency.agencyId,
                 'name': agency.businessName,
-                'avatar': agency.profileImg,
-                'contact': agency.contactNum,
+                'avatar': None,  # Agency model doesn't have profile image field
+                'contact': agency.contactNumber,  # Fixed: was contactNum (wrong field name)
             }
         
         # Build client info


### PR DESCRIPTION
Fixes mobile receipt generation error when job is assigned to an Agency. The endpoint was using non-existent Agency field names (profileImg, contactNum). Changed to None and contactNumber respectively.