### PR TITLE
fix: Team hiring jobs now properly create skill slots

### DIFF
--- a/apps/backend/src/jobs/schemas.py
+++ b/apps/backend/src/jobs/schemas.py
@@ -15,6 +15,14 @@ class CreateJobPostingSchema(Schema):
     payment_method: Optional[str] = "WALLET"  # WALLET or GCASH
 
 
+class MobileSkillSlotSchema(Schema):
+    """Schema for skill slots sent from mobile app"""
+    specialization_id: int
+    workers_needed: int = 1
+    skill_level_required: Optional[str] = "ENTRY"  # ENTRY, INTERMEDIATE, EXPERT
+    notes: Optional[str] = None
+
+
 class CreateJobPostingMobileSchema(Schema):
     """Mobile-specific job posting schema with optional worker_id for direct hiring"""
     title: str
@@ -29,6 +37,7 @@ class CreateJobPostingMobileSchema(Schema):
     payment_method: Optional[str] = "WALLET"  # WALLET only
     worker_id: Optional[int] = None  # If provided, job is for specific worker
     agency_id: Optional[int] = None  # If provided, job is for specific agency
+    skill_slots: Optional[list[MobileSkillSlotSchema]] = None  # For team hiring with multiple workers
 
 
 class JobPostingResponseSchema(Schema):


### PR DESCRIPTION
## Summary
Fixes the bug where team hiring jobs were being flagged as single-hire jobs and not creating JobSkillSlot records.

## Root Cause
The mobile job creation screen sends \skill_slots\ data when team hiring is enabled, but the backend \/api/jobs/create-mobile\ endpoint was ignoring it because:
1. \CreateJobPostingMobileSchema\ didn't define the \skill_slots\ field
2. The endpoint didn't process or create \JobSkillSlot\ records  
3. Jobs were created with \is_team_job=False\ regardless of skill slots

## Changes

### Backend Schema (\jobs/schemas.py\)
- Added \MobileSkillSlotSchema\ for parsing skill slot data:
  - \specialization_id: int\
  - \workers_needed: int\
  - \skill_level_required: str\
  - \
otes: str\
- Added \skill_slots: Optional[list[MobileSkillSlotSchema]]\ to \CreateJobPostingMobileSchema\

### Backend Endpoint (\jobs/api.py\)
- Added \JobSkillSlot\ import
- Detect team job: \is_team_job = bool(data.agency_id and data.skill_slots and len(data.skill_slots) > 0)\
- Set \is_team_job=True\ when creating job posting
- Create \JobSkillSlot\ records with:
  - Auto-calculated \udget_allocated = job.budget / num_slots\
  - \workers_needed\, \skill_level_required\ from mobile data
  - Status = 'OPEN'

## Result
- Team jobs now correctly flagged with \is_team_job=True\
- \JobSkillSlot\ records created in database
- Agency pending invite cards will now display skill slots correctly

## Testing
- [ ] Create team job from mobile with 4 workers across 1 skill slot (Appliance Repair, Intermediate)
- [ ] Verify job has \is_team_job=True\ in database
- [ ] Verify \JobSkillSlot\ record exists with \workers_needed=4\
- [ ] Verify agency pending invite card shows TEAM JOB badge and skill slots