### PR TITLE
Fix skill slot employee matching by specialization name

### DIFF
--- a/apps/frontend_web/app/agency/jobs/page.tsx
+++ b/apps/frontend_web/app/agency/jobs/page.tsx
@@ -31,7 +31,7 @@ interface Employee {
   rating: number;
   totalJobsCompleted: number;
   isActive: boolean;
-  specializations?: number[];
+  specializations?: string[]; // List of specialization names (strings from backend)
 }
 
 const normalizeEmployee = (employee: any): Employee => {

--- a/apps/frontend_web/components/agency/SkillSlotAssignmentModal.tsx
+++ b/apps/frontend_web/components/agency/SkillSlotAssignmentModal.tsx
@@ -29,7 +29,7 @@ interface Employee {
   rating: number | null;
   totalJobsCompleted: number;
   isActive: boolean;
-  specializations?: number[]; // List of specialization IDs employee has
+  specializations?: string[]; // List of specialization names employee has
   workload?: EmployeeWorkload;
 }
 
@@ -137,9 +137,13 @@ export default function SkillSlotAssignmentModal({
   const getEligibleEmployeesForSlot = (slot: JobSkillSlot): Employee[] => {
     return employees.filter((emp) => {
       if (!emp.isActive) return false;
-      // Check if employee has the required specialization
+      // Check if employee has the required specialization (match by name)
       if (emp.specializations && emp.specializations.length > 0) {
-        return emp.specializations.includes(slot.specialization_id);
+        // Case-insensitive match on specialization name
+        const slotSpecName = slot.specialization_name.toLowerCase();
+        return emp.specializations.some(
+          (spec) => spec.toLowerCase() === slotSpecName
+        );
       }
       // If no specializations data, allow all (fallback for legacy data)
       return true;


### PR DESCRIPTION
Employees were not showing in the Assign Team modal even when they had matching specializations.

**Root Cause:** Backend returns specializations as an array of **strings** (category names like 'Carpentry'), but frontend was trying to match against **specialization_id** (number).

**Fix:** Changed matching logic to compare by specialization **name** (case-insensitive) instead of ID.