### PR TITLE
Fix agency job invite flow - separate accept and assign

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -1585,9 +1585,11 @@ def assign_employees_to_slots_endpoint(request, job_id: int):
     """
     import json
     try:
+        print(f"📋 assign_employees_to_slots_endpoint called for job_id={job_id}")
         data = json.loads(request.body)
         assignments = data.get('assignments', [])
         primary_contact_employee_id = data.get('primary_contact_employee_id')
+        print(f"   Assignments count: {len(assignments)}, Primary contact: {primary_contact_employee_id}")
         
         if not assignments:
             return Response({'success': False, 'error': 'assignments list is required'}, status=400)

--- a/apps/backend/src/agency/services.py
+++ b/apps/backend/src/agency/services.py
@@ -2253,28 +2253,37 @@ def assign_employees_to_slots(
     from django.db import transaction
     import json
     
+    print(f"📋 assign_employees_to_slots service called: job_id={job_id}, assignments={len(assignments)}")
+    
     # Get agency
     try:
         agency = AgencyProfile.objects.get(accountFK=agency_account)
+        print(f"   Found agency: {agency.businessName}")
     except AgencyProfile.DoesNotExist:
+        print(f"   ❌ Agency not found for account {agency_account}")
         return {'success': False, 'error': 'Agency account not found'}
     
     # Get job
     try:
         job = Job.objects.select_related('assignedAgencyFK', 'clientID__profileID__accountFK').get(jobID=job_id)
+        print(f"   Found job: {job.title}, status={job.status}, inviteStatus={job.inviteStatus}")
     except Job.DoesNotExist:
+        print(f"   ❌ Job {job_id} not found")
         return {'success': False, 'error': f'Job {job_id} not found'}
     
     # Verify job belongs to this agency
     if job.assignedAgencyFK != agency:
+        print(f"   ❌ Job not assigned to this agency (assigned to {job.assignedAgencyFK})")
         return {'success': False, 'error': 'This job is not assigned to your agency'}
     
     # Verify it's a multi-employee job
     if not job.is_team_job:
+        print(f"   ❌ Not a team job")
         return {'success': False, 'error': 'This is not a multi-employee job. Use regular employee assignment.'}
     
     # Verify job is in correct status (ACTIVE with ACCEPTED invite)
     if job.inviteStatus != 'ACCEPTED':
+        print(f"   ❌ Job invite not accepted yet (current: {job.inviteStatus})")
         return {'success': False, 'error': 'Job invite must be accepted before assigning employees'}
     
     # Get all skill slots for this job


### PR DESCRIPTION
## Summary
Fixes the agency job invite flow by separating accept and assign into two distinct steps.

### Problem
- When clicking Accept on a pending invite, the modal tried to accept AND assign employees in one step
- This caused 'Internal server error' because backend requires inviteStatus=ACCEPTED before assignment
- Flow was confusing to users

### Solution
**New Flow:**
1. **Pending Invites tab**: Click 'Accept Invitation'  Only accepts the job  Redirects to Accepted tab
2. **Accepted tab**: Click 'Assign Employees'  Opens assignment modal  Assigns workers

### Changes
**Frontend (jobs/page.tsx):**
- handleAcceptInvite now only calls accept API, shows success, redirects to Accepted tab
- Removed isPendingInviteFlow logic from handleAssignEmployees and handleAssignToSlots
- Simplified success messages

**Backend (api.py, services.py):**
- Added detailed logging for debugging assign_employees_to_slots endpoint
- Logs job status, invite status, agency info