### PR TITLE
fix: correct Conversation import in assign_employees_to_slots service

### DIFF
--- a/apps/backend/src/agency/services.py
+++ b/apps/backend/src/agency/services.py
@@ -2247,7 +2247,8 @@ def assign_employees_to_slots(
         - Employees must have the specialization matching the slot (strict matching)
         - Each employee can only be assigned to one slot per job
     """
-    from accounts.models import Job, JobSkillSlot, JobEmployeeAssignment, Notification, JobLog, Specializations, Conversation
+    from accounts.models import Job, JobSkillSlot, JobEmployeeAssignment, Notification, JobLog, Specializations
+    from profiles.models import Conversation
     from .models import AgencyEmployee
     from django.utils import timezone
     from django.db import transaction

--- a/tests/test_assign_employees_to_slots.http
+++ b/tests/test_assign_employees_to_slots.http
@@ -1,0 +1,39 @@
+### Test assign-employees-to-slots endpoint
+### This tests the fix for Conversation import error
+
+@baseUrl = http://localhost:8000
+
+### 1. Login as agency user first
+# @name login
+POST {{baseUrl}}/api/accounts/login
+Content-Type: application/json
+
+{
+  "email": "agency@test.com",
+  "password": "password123"
+}
+
+### 2. Get agency jobs to find a team job with skill slots
+# @name getJobs
+GET {{baseUrl}}/api/agency/jobs?status=ACTIVE
+Cookie: {{login.response.headers.set-cookie}}
+
+### 3. Get skill slots for a specific job (replace JOB_ID with actual ID)
+# @name getSlots
+GET {{baseUrl}}/api/agency/jobs/123/skill-slots
+Cookie: {{login.response.headers.set-cookie}}
+
+### 4. Assign employees to slots (replace with actual IDs)
+# This is the endpoint that was returning "Internal server error"
+# Should now work after fixing Conversation import
+# @name assignEmployees
+POST {{baseUrl}}/api/agency/jobs/123/assign-employees-to-slots
+Content-Type: application/json
+Cookie: {{login.response.headers.set-cookie}}
+
+{
+  "assignments": [
+    {"skill_slot_id": 1, "employee_id": 1}
+  ],
+  "primary_contact_employee_id": 1
+}


### PR DESCRIPTION
## Problem
The \/api/agency/jobs/{job_id}/assign-employees-to-slots\ endpoint was returning \{success: false, error: 'Internal server error'}\.

## Root Cause
The \ssign_employees_to_slots\ service function in \gency/services.py\ was importing \Conversation\ from \ccounts.models\, but the model actually lives in \profiles.models\.

**Before:**
\\\python
from accounts.models import Job, JobSkillSlot, JobEmployeeAssignment, Notification, JobLog, Specializations, Conversation
\\\

**After:**
\\\python
from accounts.models import Job, JobSkillSlot, JobEmployeeAssignment, Notification, JobLog, Specializations
from profiles.models import Conversation
\\\

## Changes
- Fixed the import statement on line 2250-2251 of \gency/services.py\
- Added test file for the endpoint

## Testing
- Python syntax check: ✅ Passes
- Backend restart: ✅ No import errors
- Manual testing: Ready for UI verification