### PR TITLE
fix(workflow): fix deployment ID parsing for DigitalOcean

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -93,10 +93,15 @@ jobs:
             echo "✅ Deployment created successfully!"
             echo "$deployment_output"
             
-            # Extract deployment ID
-            deployment_id=$(echo "$deployment_output" | awk '{print $1}')
-            echo "DEPLOYMENT_ID=$deployment_id" >> $GITHUB_ENV
-            echo "Deployment ID: $deployment_id"
+            # Extract deployment ID (skip 'Notice:' lines, grep for UUID)
+            deployment_id=$(echo "$deployment_output" | grep -E '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | head -1 | awk '{print $1}')
+            
+            if [ -n "$deployment_id" ]; then
+              echo "DEPLOYMENT_ID=$deployment_id" >> "$GITHUB_ENV"
+              echo "Deployment ID: $deployment_id"
+            else
+              echo "⚠️ Could not extract deployment ID, but deployment created"
+            fi
           else
             echo "❌ Failed to create deployment"
             echo "$deployment_output"


### PR DESCRIPTION
## Changes

Fixed the deployment ID extraction in the DigitalOcean deploy workflow.

### Issue
The workflow was failing with:
\\\
Error: Unable to process file command 'env' successfully.
Error: Invalid format 'afd61aa9-3868-4f59-9012-4b511dcc9dbf'
\\\

### Root Cause
\doctl apps create-deployment\ outputs a 'Notice:' line before the actual deployment data:
\\\
Notice: Deployment created
afd61aa9-3868-4f59-9012-4b511dcc9dbf    PENDING_BUILD
\\\

The previous \wk '{print }'\ was capturing 'Notice:' instead of the UUID.

### Solution
- Added \grep -E\ with UUID regex pattern to extract only the deployment ID line
- Skips any 'Notice:' or other text lines
- Added fallback handling if deployment ID cannot be extracted

### Path Filters
Kept the original path filters - workflow only triggers on backend code changes:
- \pps/backend/**\
- \Dockerfile\
- \docker-compose.yml\
- \equirements.txt\

## Testing
Will auto-trigger on merge when backend files change.