### PR TITLE
fix: Add missing closing braces to StyleSheet.create() in job creation screen

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app/jobs/create/index.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/jobs/create/index.tsx
@@ -2740,3 +2740,4 @@ const styles = StyleSheet.create({
     borderTopColor: Colors.border,
     fontStyle: "italic",
   },
+});


### PR DESCRIPTION
## Problem

Metro bundler was throwing a syntax error preventing the mobile app from compiling:

`
ERROR  SyntaxError: C:\code\iayos\apps\frontend_mobile\iayos_mobile\app\jobs\create\index.tsx: Unexpected token (2743:0)
  2741 |     fontStyle: 'italic',
  2742 |   },
> 2743 |
       | ^
`

**Root Cause**: The file was missing }); to close the StyleSheet.create() block that starts at line 1805.

## Solution

Added the missing closing braces at the end of the file:

`	sx
  dailyNote: {
    fontSize: 13,
    color: Colors.textSecondary,
    marginTop: 12,
    paddingTop: 12,
    borderTopWidth: 1,
    borderTopColor: Colors.border,
    fontStyle: 'italic',
  },
});  // ← Added this line
`

## Testing

✅ **TypeScript Compilation**: 0 errors
- Checked pp/jobs/create/index.tsx
- Checked 	ypes/index.ts

✅ **File Structure**: Complete
- StyleSheet.create() properly closed
- All style objects syntactically correct

## Impact

- **Critical Fix**: Unblocks mobile app development and testing
- **No Logic Changes**: Only syntax correction
- **Related**: Follows up on PR #258 (Daily Payment UI)

## Files Changed

- pps/frontend_mobile/iayos_mobile/app/jobs/create/index.tsx (+1 line)

---

**Note**: This was discovered while investigating camera guide overlays from commit 6b3d00c (PR #240). The camera implementation is correct - no package migration occurred, still using xpo-image-picker with pre-capture guidance modal.