### PR TITLE
feat(mobile): add expo-camera with real-time ID card guide overlay

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -67,7 +67,13 @@
         }
       ],
       "expo-secure-store",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "iAyos needs camera access to capture your ID documents for verification."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/frontend_mobile/iayos_mobile/app/kyc/camera.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/kyc/camera.tsx
@@ -1,0 +1,592 @@
+/**
+ * KYC Camera Screen with ID Card Guide Overlay
+ *
+ * Uses expo-camera's CameraView component to render camera preview IN-APP
+ * with React Native overlay components for real-time framing guidance.
+ *
+ * Works with Expo Go - no custom dev client required.
+ */
+
+import React, { useRef, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+  StatusBar,
+  Platform,
+  Linking,
+} from "react-native";
+import { CameraView, useCameraPermissions, FlashMode } from "expo-camera";
+import { Stack, useRouter, useLocalSearchParams } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Colors, Typography } from "@/constants/theme";
+import { cameraEvents } from "@/lib/utils/cameraEvents";
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
+
+// ID card standard dimensions: 85.6mm x 53.98mm (aspect ratio ~1.586)
+const FRAME_WIDTH = SCREEN_WIDTH * 0.85;
+const FRAME_HEIGHT_ID = FRAME_WIDTH * 0.63; // For ID cards
+const FRAME_HEIGHT_CLEARANCE = FRAME_WIDTH * 0.9; // Taller for clearance docs
+const OVAL_SIZE = SCREEN_WIDTH * 0.7; // For selfie
+
+type DocumentType = "front" | "back" | "clearance" | "selfie";
+
+interface GuideConfig {
+  shape: "rectangle" | "oval";
+  title: string;
+  subtitle: string;
+  frameWidth: number;
+  frameHeight: number;
+  facing: "front" | "back";
+}
+
+const getGuideConfig = (documentType: DocumentType): GuideConfig => {
+  switch (documentType) {
+    case "selfie":
+      return {
+        shape: "oval",
+        title: "Position Your Face",
+        subtitle: "Center your face within the oval frame",
+        frameWidth: OVAL_SIZE,
+        frameHeight: OVAL_SIZE * 1.3,
+        facing: "front",
+      };
+    case "clearance":
+      return {
+        shape: "rectangle",
+        title: "Position NBI/Police Clearance",
+        subtitle: "Align all corners within the frame",
+        frameWidth: FRAME_WIDTH,
+        frameHeight: FRAME_HEIGHT_CLEARANCE,
+        facing: "back",
+      };
+    case "back":
+      return {
+        shape: "rectangle",
+        title: "Position ID Card (Back)",
+        subtitle: "Flip your ID and align within frame",
+        frameWidth: FRAME_WIDTH,
+        frameHeight: FRAME_HEIGHT_ID,
+        facing: "back",
+      };
+    default: // 'front'
+      return {
+        shape: "rectangle",
+        title: "Position ID Card (Front)",
+        subtitle: "Align all corners within the frame",
+        frameWidth: FRAME_WIDTH,
+        frameHeight: FRAME_HEIGHT_ID,
+        facing: "back",
+      };
+  }
+};
+
+export default function KYCCameraScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ documentType: DocumentType }>();
+  const documentType = (params.documentType as DocumentType) || "front";
+
+  const cameraRef = useRef<CameraView>(null);
+  const [permission, requestPermission] = useCameraPermissions();
+  const [flashMode, setFlashMode] = useState<FlashMode>("off");
+  const [isCapturing, setIsCapturing] = useState(false);
+
+  const config = getGuideConfig(documentType);
+
+  // Permission not determined yet
+  if (!permission) {
+    return (
+      <View style={styles.container}>
+        <StatusBar barStyle="light-content" />
+        <View style={styles.loadingContainer}>
+          <Ionicons name="camera-outline" size={48} color={Colors.textHint} />
+          <Text style={styles.loadingText}>Initializing camera...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Permission denied - show request screen
+  if (!permission.granted) {
+    return (
+      <View style={styles.container}>
+        <StatusBar barStyle="dark-content" />
+        <Stack.Screen options={{ headerShown: false }} />
+
+        <View style={[styles.permissionContainer, { paddingTop: insets.top }]}>
+          {/* Header */}
+          <TouchableOpacity
+            style={styles.permissionCloseButton}
+            onPress={() => router.back()}
+          >
+            <Ionicons name="close" size={24} color={Colors.textPrimary} />
+          </TouchableOpacity>
+
+          {/* Content */}
+          <View style={styles.permissionContent}>
+            <View style={styles.permissionIconContainer}>
+              <Ionicons name="camera" size={64} color={Colors.primary} />
+            </View>
+
+            <Text style={styles.permissionTitle}>Camera Access Required</Text>
+
+            <Text style={styles.permissionDescription}>
+              To capture your ID documents for KYC verification, iAyos needs
+              access to your camera. Your photos are securely processed and
+              never shared with third parties.
+            </Text>
+
+            <View style={styles.permissionFeatures}>
+              <View style={styles.permissionFeatureRow}>
+                <Ionicons
+                  name="shield-checkmark"
+                  size={20}
+                  color={Colors.success}
+                />
+                <Text style={styles.permissionFeatureText}>
+                  Secure document capture
+                </Text>
+              </View>
+              <View style={styles.permissionFeatureRow}>
+                <Ionicons name="eye-off" size={20} color={Colors.success} />
+                <Text style={styles.permissionFeatureText}>
+                  Photos stay on your device until upload
+                </Text>
+              </View>
+              <View style={styles.permissionFeatureRow}>
+                <Ionicons name="lock-closed" size={20} color={Colors.success} />
+                <Text style={styles.permissionFeatureText}>
+                  Encrypted transmission
+                </Text>
+              </View>
+            </View>
+
+            <TouchableOpacity
+              style={styles.permissionButton}
+              onPress={requestPermission}
+            >
+              <Ionicons name="camera" size={20} color={Colors.white} />
+              <Text style={styles.permissionButtonText}>
+                Allow Camera Access
+              </Text>
+            </TouchableOpacity>
+
+            {permission.canAskAgain === false && (
+              <TouchableOpacity
+                style={styles.settingsButton}
+                onPress={() => Linking.openSettings()}
+              >
+                <Text style={styles.settingsButtonText}>Open Settings</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  // Handle photo capture
+  const handleCapture = async () => {
+    if (!cameraRef.current || isCapturing) return;
+
+    setIsCapturing(true);
+    try {
+      const photo = await cameraRef.current.takePictureAsync({
+        quality: 0.9,
+        skipProcessing: false,
+      });
+
+      if (photo?.uri) {
+        // Emit the captured photo URI to listeners in upload.tsx
+        cameraEvents.emit(documentType, photo.uri);
+        // Navigate back to the upload screen
+        router.back();
+      }
+    } catch (error) {
+      console.error("Camera capture error:", error);
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
+  // Toggle flash
+  const toggleFlash = () => {
+    setFlashMode((prev) => (prev === "off" ? "on" : "off"));
+  };
+
+  // Handle close
+  const handleClose = () => {
+    router.back();
+  };
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <Stack.Screen options={{ headerShown: false }} />
+
+      {/* Camera Preview - Full Screen */}
+      <CameraView
+        ref={cameraRef}
+        style={StyleSheet.absoluteFill}
+        facing={config.facing}
+        flash={flashMode}
+      >
+        {/* ===== OVERLAY LAYER - RENDERS ON TOP OF CAMERA ===== */}
+
+        {/* Dark overlay with transparent cutout */}
+        <View style={styles.overlayContainer} pointerEvents="none">
+          {/* Top dark section */}
+          <View style={styles.darkSection} />
+
+          {/* Middle row with frame cutout */}
+          <View style={styles.middleRow}>
+            <View style={styles.darkSection} />
+
+            {/* Transparent frame area */}
+            <View
+              style={[
+                styles.frame,
+                {
+                  width: config.frameWidth,
+                  height: config.frameHeight,
+                },
+                config.shape === "oval" && styles.ovalFrame,
+              ]}
+            >
+              {/* Corner markers for rectangle */}
+              {config.shape === "rectangle" && (
+                <>
+                  <View style={[styles.corner, styles.cornerTL]} />
+                  <View style={[styles.corner, styles.cornerTR]} />
+                  <View style={[styles.corner, styles.cornerBL]} />
+                  <View style={[styles.corner, styles.cornerBR]} />
+                </>
+              )}
+            </View>
+
+            <View style={styles.darkSection} />
+          </View>
+
+          {/* Bottom dark section */}
+          <View style={styles.darkSection} />
+        </View>
+
+        {/* Guidance text at top */}
+        <View style={[styles.guidanceContainer, { top: insets.top + 60 }]}>
+          <Text style={styles.guidanceTitle}>{config.title}</Text>
+          <Text style={styles.guidanceSubtitle}>{config.subtitle}</Text>
+        </View>
+
+        {/* Tips */}
+        <View style={styles.tipsContainer}>
+          <View style={styles.tipRow}>
+            <Ionicons name="sunny-outline" size={16} color={Colors.white} />
+            <Text style={styles.tipText}>Good lighting</Text>
+          </View>
+          <View style={styles.tipRow}>
+            <Ionicons name="hand-left-outline" size={16} color={Colors.white} />
+            <Text style={styles.tipText}>Hold steady</Text>
+          </View>
+          <View style={styles.tipRow}>
+            <Ionicons name="eye-outline" size={16} color={Colors.white} />
+            <Text style={styles.tipText}>Clear text</Text>
+          </View>
+        </View>
+
+        {/* Controls */}
+        <View style={[styles.controls, { paddingBottom: insets.bottom + 20 }]}>
+          {/* Close button */}
+          <TouchableOpacity style={styles.controlButton} onPress={handleClose}>
+            <Ionicons name="close" size={28} color={Colors.white} />
+          </TouchableOpacity>
+
+          {/* Capture button */}
+          <TouchableOpacity
+            style={[
+              styles.captureButton,
+              isCapturing && styles.captureButtonDisabled,
+            ]}
+            onPress={handleCapture}
+            disabled={isCapturing}
+          >
+            <View style={styles.captureButtonInner} />
+          </TouchableOpacity>
+
+          {/* Flash toggle (only for back camera) */}
+          {config.facing === "back" ? (
+            <TouchableOpacity
+              style={styles.controlButton}
+              onPress={toggleFlash}
+            >
+              <Ionicons
+                name={flashMode === "on" ? "flash" : "flash-off"}
+                size={24}
+                color={Colors.white}
+              />
+            </TouchableOpacity>
+          ) : (
+            <View style={styles.controlButton} />
+          )}
+        </View>
+      </CameraView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+
+  // Loading state
+  loadingContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 16,
+  },
+  loadingText: {
+    ...Typography.body.medium,
+    color: Colors.textHint,
+  },
+
+  // Permission screen
+  permissionContainer: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  permissionCloseButton: {
+    position: "absolute",
+    top: 60,
+    left: 16,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: Colors.backgroundSecondary,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 1,
+  },
+  permissionContent: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32,
+  },
+  permissionIconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: `${Colors.primary}15`,
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  permissionTitle: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: Colors.textPrimary,
+    textAlign: "center",
+    marginBottom: 12,
+  },
+  permissionDescription: {
+    ...Typography.body.medium,
+    color: Colors.textSecondary,
+    textAlign: "center",
+    lineHeight: 22,
+    marginBottom: 24,
+  },
+  permissionFeatures: {
+    alignSelf: "stretch",
+    gap: 12,
+    marginBottom: 32,
+  },
+  permissionFeatureRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  permissionFeatureText: {
+    ...Typography.body.medium,
+    color: Colors.textPrimary,
+  },
+  permissionButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    backgroundColor: Colors.primary,
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 12,
+    alignSelf: "stretch",
+  },
+  permissionButtonText: {
+    ...Typography.body.medium,
+    color: Colors.white,
+    fontWeight: "600",
+  },
+  settingsButton: {
+    marginTop: 16,
+    paddingVertical: 12,
+  },
+  settingsButtonText: {
+    ...Typography.body.medium,
+    color: Colors.primary,
+    fontWeight: "600",
+  },
+
+  // Overlay
+  overlayContainer: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  darkSection: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+  },
+  middleRow: {
+    flexDirection: "row",
+  },
+  frame: {
+    backgroundColor: "transparent",
+    borderWidth: 2,
+    borderColor: "rgba(255, 255, 255, 0.5)",
+    borderRadius: 12,
+  },
+  ovalFrame: {
+    borderRadius: 1000,
+  },
+
+  // Corner markers
+  corner: {
+    position: "absolute",
+    width: 28,
+    height: 28,
+    borderColor: Colors.primary,
+    borderWidth: 4,
+  },
+  cornerTL: {
+    top: -2,
+    left: -2,
+    borderRightWidth: 0,
+    borderBottomWidth: 0,
+    borderTopLeftRadius: 12,
+  },
+  cornerTR: {
+    top: -2,
+    right: -2,
+    borderLeftWidth: 0,
+    borderBottomWidth: 0,
+    borderTopRightRadius: 12,
+  },
+  cornerBL: {
+    bottom: -2,
+    left: -2,
+    borderRightWidth: 0,
+    borderTopWidth: 0,
+    borderBottomLeftRadius: 12,
+  },
+  cornerBR: {
+    bottom: -2,
+    right: -2,
+    borderLeftWidth: 0,
+    borderTopWidth: 0,
+    borderBottomRightRadius: 12,
+  },
+
+  // Guidance
+  guidanceContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    alignItems: "center",
+    paddingHorizontal: 20,
+  },
+  guidanceTitle: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: Colors.white,
+    textAlign: "center",
+    textShadowColor: "rgba(0, 0, 0, 0.8)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+  guidanceSubtitle: {
+    fontSize: 14,
+    color: "rgba(255, 255, 255, 0.85)",
+    textAlign: "center",
+    marginTop: 6,
+    textShadowColor: "rgba(0, 0, 0, 0.8)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 4,
+  },
+
+  // Tips
+  tipsContainer: {
+    position: "absolute",
+    bottom: 160,
+    left: 0,
+    right: 0,
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 24,
+  },
+  tipRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  tipText: {
+    fontSize: 12,
+    color: Colors.white,
+    textShadowColor: "rgba(0, 0, 0, 0.6)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
+
+  // Controls
+  controls: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    flexDirection: "row",
+    justifyContent: "space-around",
+    alignItems: "center",
+    paddingHorizontal: 32,
+    paddingTop: 20,
+  },
+  controlButton: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: "rgba(0, 0, 0, 0.4)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  captureButton: {
+    width: 76,
+    height: 76,
+    borderRadius: 38,
+    backgroundColor: "rgba(255, 255, 255, 0.25)",
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 4,
+    borderColor: Colors.white,
+  },
+  captureButtonDisabled: {
+    opacity: 0.5,
+  },
+  captureButtonInner: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: Colors.white,
+  },
+});

--- a/apps/frontend_mobile/iayos_mobile/lib/utils/cameraEvents.ts
+++ b/apps/frontend_mobile/iayos_mobile/lib/utils/cameraEvents.ts
@@ -1,0 +1,62 @@
+/**
+ * Camera Events - Simple event emitter for camera capture results
+ *
+ * Since Expo Router doesn't support returning values from navigated screens,
+ * we use a simple event-based system to communicate captured photo URIs
+ * from the camera screen back to the calling screen.
+ */
+
+type CaptureCallback = (uri: string) => void;
+type DocumentType = "front" | "back" | "clearance" | "selfie";
+
+class CameraEventEmitter {
+  private listeners: Map<DocumentType, CaptureCallback[]> = new Map();
+
+  /**
+   * Subscribe to capture events for a specific document type
+   */
+  on(documentType: DocumentType, callback: CaptureCallback): () => void {
+    const existing = this.listeners.get(documentType) || [];
+    this.listeners.set(documentType, [...existing, callback]);
+
+    // Return unsubscribe function
+    return () => {
+      const callbacks = this.listeners.get(documentType) || [];
+      this.listeners.set(
+        documentType,
+        callbacks.filter((cb) => cb !== callback),
+      );
+    };
+  }
+
+  /**
+   * Emit a capture event with the photo URI
+   */
+  emit(documentType: DocumentType, uri: string): void {
+    const callbacks = this.listeners.get(documentType) || [];
+    callbacks.forEach((callback) => {
+      try {
+        callback(uri);
+      } catch (error) {
+        console.error("[CameraEvents] Callback error:", error);
+      }
+    });
+  }
+
+  /**
+   * Clear all listeners for a specific document type
+   */
+  clear(documentType: DocumentType): void {
+    this.listeners.delete(documentType);
+  }
+
+  /**
+   * Clear all listeners
+   */
+  clearAll(): void {
+    this.listeners.clear();
+  }
+}
+
+// Singleton instance
+export const cameraEvents = new CameraEventEmitter();

--- a/apps/frontend_mobile/iayos_mobile/package-lock.json
+++ b/apps/frontend_mobile/iayos_mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iayos_mobile",
-  "version": "1.15.6",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iayos_mobile",
-      "version": "1.15.6",
+      "version": "1.18.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -21,6 +21,7 @@
         "date-fns": "^4.1.0",
         "expo": "~54.0.33",
         "expo-build-properties": "~1.0.10",
+        "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.10",
         "expo-device": "~8.0.10",
         "expo-file-system": "~19.0.19",
@@ -98,6 +99,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3893,6 +3895,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.20.tgz",
       "integrity": "sha512-15luFq+35M2IOMHgbTJ0XDkPY7gm3YlR3yQKTuOTOHs+EeAUX71DlUuqcWMRqB0tt+OT6HimDQR7OboTB0N30g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.13.1",
         "escape-string-regexp": "^4.0.0",
@@ -4117,6 +4120,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4188,6 +4192,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -4737,6 +4742,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5470,6 +5476,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6489,6 +6496,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6685,6 +6693,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6949,6 +6958,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -7055,11 +7065,32 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/expo-camera": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.10.tgz",
+      "integrity": "sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -7096,6 +7127,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7190,6 +7222,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -11202,6 +11235,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11221,6 +11255,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -11257,6 +11292,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -11366,6 +11402,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -11436,6 +11473,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.5.tgz",
       "integrity": "sha512-UA6VUbxwhRjEw2gSNrvhkusUq3upfD3Cv+AnB07V+kC8kpvwRVI+ivwY95ePbWNFkFpP+Y2Sdw1WHpHWEV+P2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -11464,6 +11502,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -11474,6 +11513,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -11499,6 +11539,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -11531,6 +11572,7 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
       "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -11545,6 +11587,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11620,6 +11663,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13252,6 +13296,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/apps/frontend_mobile/iayos_mobile/package.json
+++ b/apps/frontend_mobile/iayos_mobile/package.json
@@ -25,6 +25,7 @@
     "date-fns": "^4.1.0",
     "expo": "~54.0.33",
     "expo-build-properties": "~1.0.10",
+    "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.10",
     "expo-device": "~8.0.10",
     "expo-file-system": "~19.0.19",


### PR DESCRIPTION
## Summary
- Install expo-camera package for in-app camera with overlay support
- Create /kyc/camera screen with CameraView and document framing guide
- Add dark overlay with transparent cutout and corner markers
- Support different frame shapes (rectangle for ID, oval for selfie, taller for clearance)
- Add flash toggle and permission request screen
- Create cameraEvents module for passing photo URI back to upload screen
- Update upload.tsx to navigate to camera screen instead of native picker
- Remove pre-capture modal (replaced by real-time overlay)

## Problem
expo-image-picker launches the native camera app which:
1. Crashes on some devices
2. Doesn't allow custom overlays/guide frames
3. Provides no real-time framing guidance

## Solution
expo-camera's CameraView renders the camera preview IN-APP with React Native children rendering ON TOP of the camera feed. This allows:
- Real-time ID card frame overlay with corner markers
- Guidance text and tips visible during capture
- Flash toggle control
- Permission request screen with explanation
- Works with Expo Go (no custom dev client needed)

## Files Changed
- apps/frontend_mobile/iayos_mobile/app.json - Added expo-camera plugin
- apps/frontend_mobile/iayos_mobile/app/kyc/camera.tsx - NEW camera screen (592 lines)
- apps/frontend_mobile/iayos_mobile/lib/utils/cameraEvents.ts - NEW event emitter (57 lines)
- apps/frontend_mobile/iayos_mobile/app/kyc/upload.tsx - Updated to use camera screen
- apps/frontend_mobile/iayos_mobile/package.json - Added expo-camera dependency

## Testing
- [ ] Test camera permission request on fresh install
- [ ] Test ID front capture with frame overlay
- [ ] Test ID back capture
- [ ] Test clearance capture (taller frame)
- [ ] Test selfie capture (oval frame, front camera)
- [ ] Test flash toggle
- [ ] Test close button returns to upload screen
- [ ] Verify captured photo is received and validated