### PR TITLE
fix(mobile): remove invalid update section from eas.json

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/eas.json
+++ b/apps/frontend_mobile/iayos_mobile/eas.json
@@ -40,14 +40,6 @@
       }
     }
   },
-  "update": {
-    "production": {
-      "channel": "production"
-    },
-    "preview": {
-      "channel": "preview"
-    }
-  },
   "submit": {
     "production": {
       "android": {


### PR DESCRIPTION
## Problem
Mobile release workflow failing with eas.json validation error - update is not allowed

## Root Cause
The update section at root level is not a valid configuration in eas.json according to the current EAS CLI validation rules.

## Solution
Removed the invalid update section. The channel property already exists correctly within each build profile.

## Changes
- apps/frontend_mobile/iayos_mobile/eas.json: Removed invalid update section