### PR TITLE
fix(mobile): remove resourceClass large (requires paid subscription)

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/eas.json
+++ b/apps/frontend_mobile/iayos_mobile/eas.json
@@ -30,8 +30,7 @@
       "channel": "production",
       "android": {
         "buildType": "apk",
-        "prebuildCommand": "npx expo prebuild --clean",
-        "resourceClass": "large"
+        "prebuildCommand": "npx expo prebuild --clean"
       },
       "ios": {
         "resourceClass": "m1-medium"


### PR DESCRIPTION
Removes resourceClass: large from Android production builds - requires paid EAS subscription. Uses default free tier cloud builder instead.