### PR TITLE
fix(agency): filter conversations by logged-in agency only

### DIFF
--- a/tests/agency_conversations_filter_fix_test.http
+++ b/tests/agency_conversations_filter_fix_test.http
@@ -1,0 +1,87 @@
+### Agency Conversations Filter Fix - Test File
+### Issue: /api/agency/conversations?filter=all was returning ALL agency conversations
+### instead of only the logged-in agency's conversations
+###
+### Bug: When agency_profile=None, Q(worker=agency_profile) matched ALL conversations
+### where worker=None (i.e., ALL agency conversations)
+###
+### Fix: Removed the faulty Q(worker=agency_profile) condition
+
+@baseUrl = http://localhost:8000
+
+### =====================================================
+### SETUP: Login as downtown@gmail.com agency
+### =====================================================
+
+# @name loginDowntown
+POST {{baseUrl}}/api/agency/auth/login
+Content-Type: application/json
+
+{
+  "email": "downtown@gmail.com",
+  "password": "password123"
+}
+
+### =====================================================
+### TEST 1: Get conversations for downtown@gmail.com
+### EXPECTED: Only see "Renovate Window for restaurant" job
+### =====================================================
+
+# @name getDowntownConversations
+GET {{baseUrl}}/api/agency/conversations?filter=all
+Cookie: sessionid={{loginDowntown.response.headers.Set-Cookie}}
+
+### Should return ONLY conversations where:
+### - Q(agency=downtown_agency) OR
+### - Q(relatedJobPosting__assignedAgencyFK=downtown_agency)
+### Should NOT return conversations from devante@gmail.com or other agencies
+
+### =====================================================
+### SETUP: Login as devante@gmail.com agency (different agency)
+### =====================================================
+
+# @name loginDevante
+POST {{baseUrl}}/api/agency/auth/login
+Content-Type: application/json
+
+{
+  "email": "devante@gmail.com",
+  "password": "password123"
+}
+
+### =====================================================
+### TEST 2: Get conversations for devante@gmail.com
+### EXPECTED: Only see devante's jobs, NOT downtown's jobs
+### =====================================================
+
+# @name getDevanteConversations
+GET {{baseUrl}}/api/agency/conversations?filter=all
+Cookie: sessionid={{loginDevante.response.headers.Set-Cookie}}
+
+### Should return ONLY devante's conversations
+### Should NOT include "Renovate Window for restaurant" (belongs to downtown)
+
+### =====================================================
+### TEST 3: Verify unread filter also works correctly
+### =====================================================
+
+# @name getDowntownUnread
+GET {{baseUrl}}/api/agency/conversations?filter=unread
+Cookie: sessionid={{loginDowntown.response.headers.Set-Cookie}}
+
+### =====================================================
+### TEST 4: Verify archived filter also works correctly
+### =====================================================
+
+# @name getDowntownArchived
+GET {{baseUrl}}/api/agency/conversations?filter=archived
+Cookie: sessionid={{loginDowntown.response.headers.Set-Cookie}}
+
+### =====================================================
+### VALIDATION CHECKLIST
+### =====================================================
+### ✅ downtown@gmail.com only sees downtown's conversations
+### ✅ devante@gmail.com only sees devante's conversations
+### ✅ "Renovate Window for restaurant" appears ONLY in downtown's results
+### ✅ No cross-agency data leakage
+### ✅ All filter types (all, unread, archived) work correctly


### PR DESCRIPTION
## Problem
\/api/agency/conversations?filter=all\ was returning conversations from **ALL agencies** instead of only the logged-in agency's conversations.

**User report**: Logged in as \downtown@gmail.com\ agency, but seeing conversations belonging to \devante@gmail.com\ and other agencies. Only 'Renovate Window for restaurant' should appear.

## Root Cause
The query at line 1773-1777 had a faulty condition:
\\\python
Q(worker=agency_profile) |  # BUG!
Q(agency=agency) |
Q(relatedJobPosting__assignedAgencyFK=agency)
\\\

**Issue**: Agencies don't have \Profile\ records (they use the \Agency\ model). When \gency_profile = None\, the condition \Q(worker=None)\ matched **ALL** agency conversations since they all have \worker=None\.

## Fix
1. **Removed** the faulty \Q(worker=agency_profile)\ condition from the conversations query
2. Query now correctly filters by:
   - \Q(agency=agency)\ - Direct agency link
   - \Q(relatedJobPosting__assignedAgencyFK=agency)\ - Job assigned to this agency
3. **Added** \gency\ field when creating conversations for agency jobs (line 1068)

## Changes
- \pps/backend/src/agency/api.py\ - Query fix + conversation creation fix
- \	ests/agency_conversations_filter_fix_test.http\ - Manual test file

## Testing
- [x] Python syntax check: \python -m py_compile\ passed
- [x] No TypeScript errors
- [ ] Manual testing with multiple agency accounts (requires Docker)

## Validation
After fix, each agency should only see their own conversations:
- \downtown@gmail.com\ → Only 'Renovate Window for restaurant'
- \devante@gmail.com\ → Only devante's jobs
- No cross-agency data leakage