### PR TITLE
fix(agency): remove frontend filter blocking team jobs from In Progress tab

### DIFF
--- a/apps/frontend_web/app/agency/jobs/page.tsx
+++ b/apps/frontend_web/app/agency/jobs/page.tsx
@@ -265,12 +265,8 @@ export default function AgencyJobsPage() {
       }
 
       const data = await response.json();
-      // Only show IN_PROGRESS jobs that have an assigned employee
-      // Jobs without employees should appear in Accepted tab instead
-      const jobsWithEmployees = (data.jobs || []).filter(
-        (job: Job) => job.assignedEmployeeID,
-      );
-      setInProgressJobs(jobsWithEmployees);
+      // Backend already filters by status=IN_PROGRESS, trust the backend
+      setInProgressJobs(data.jobs || []);
     } catch (err) {
       console.error("Error fetching in-progress jobs:", err);
     } finally {


### PR DESCRIPTION
Removes frontend assignedEmployeeID filter that was excluding team jobs. Backend already correctly filters and returns IN_PROGRESS jobs. Team jobs use JobWorkerAssignment instead of assignedEmployeeID field. Fixes Job #20 disappearing from all tabs.