### PR TITLE
fix: add daily payment fields to agency job APIs

### DIFF
--- a/apps/backend/src/agency/services.py
+++ b/apps/backend/src/agency/services.py
@@ -965,6 +965,13 @@ def get_agency_jobs(account_id, status_filter=None, invite_status_filter=None, p
                 'assignedEmployeeID': job.assignedEmployeeID.employeeID if job.assignedEmployeeID else None,
                 'assignedEmployee': assigned_employee,
                 'inviteStatus': job.inviteStatus,
+                # Daily payment model fields
+                'payment_model': getattr(job, 'payment_model', 'PROJECT'),
+                'daily_rate_agreed': float(job.daily_rate_agreed) if hasattr(job, 'daily_rate_agreed') and job.daily_rate_agreed else None,
+                'duration_days': job.duration_days if hasattr(job, 'duration_days') else None,
+                'actual_start_date': job.actual_start_date.isoformat() if hasattr(job, 'actual_start_date') and job.actual_start_date else None,
+                'total_days_worked': job.total_days_worked if hasattr(job, 'total_days_worked') else None,
+                'daily_escrow_total': float(job.daily_escrow_total) if hasattr(job, 'daily_escrow_total') and job.daily_escrow_total else None,
                 # Team job fields
                 'is_team_job': job.is_team_job,
                 'total_workers_needed': job.total_workers_needed,
@@ -1116,6 +1123,13 @@ def get_agency_job_detail(account_id, job_id):
             'expectedDuration': job.expectedDuration,
             'preferredStartDate': job.preferredStartDate.isoformat() if job.preferredStartDate else None,
             'materialsNeeded': materials_needed,
+            # Daily payment model fields
+            'payment_model': getattr(job, 'payment_model', 'PROJECT'),
+            'daily_rate_agreed': float(job.daily_rate_agreed) if hasattr(job, 'daily_rate_agreed') and job.daily_rate_agreed else None,
+            'duration_days': job.duration_days if hasattr(job, 'duration_days') else None,
+            'actual_start_date': job.actual_start_date.isoformat() if hasattr(job, 'actual_start_date') and job.actual_start_date else None,
+            'total_days_worked': job.total_days_worked if hasattr(job, 'total_days_worked') else None,
+            'daily_escrow_total': float(job.daily_escrow_total) if hasattr(job, 'daily_escrow_total') and job.daily_escrow_total else None,
             'assignedEmployeeID': job.assignedEmployeeID.employeeID if job.assignedEmployeeID else None,
             'assignedEmployee': assigned_employee,  # Legacy single employee
             'assignedEmployees': assigned_employees,  # NEW: All assigned employees

--- a/apps/frontend_mobile/iayos_mobile/app.json
+++ b/apps/frontend_mobile/iayos_mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "iayos_mobile",
     "slug": "iayos_mobile",
-    "version": "2.0.1",
+    "version": "2.0.3",
     "orientation": "portrait",
     "icon": "./assets/images/android-icon-foreground.png",
     "scheme": "iayosmobile",

--- a/apps/frontend_mobile/iayos_mobile/app/_layout.tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/_layout.tsx
@@ -167,6 +167,7 @@ function AppUpdateWrapper({ children }: { children: ReactNode }) {
         download={appUpdate.download}
         onApplyOTA={appUpdate.applyOTAUpdate}
         onDownloadAPK={appUpdate.downloadAndInstallAPK}
+        onInstallAPK={appUpdate.installDownloadedAPK}
       />
     </>
   );

--- a/apps/frontend_mobile/iayos_mobile/package.json
+++ b/apps/frontend_mobile/iayos_mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iayos_mobile",
   "main": "expo-router/entry",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary
Adds the 6 missing daily payment fields to agency job list and detail API responses:
- payment_model
- daily_rate_agreed
- duration_days
- actual_start_date
- total_days_worked
- daily_escrow_total

## Problem
Agency backend services were not returning daily payment fields that the frontend expects. This caused DailyJobScheduleCard and PaymentModelBadge components to render with default/empty values instead of actual job data.

## Solution
Added the 6 daily payment fields to:
1. get_agency_jobs() - line ~970
2. get_agency_job_detail() - line ~1127

Uses safe attribute access with getattr() and hasattr() for backward compatibility.

## Testing
- Verified frontend components already handle undefined with defaults
- Checked DailyJobScheduleCard.tsx has default props for all values