### PR TITLE
fix: add authenticated user validation to agency attendance endpoints

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -3559,8 +3559,15 @@ def mark_employee_arrival(request, job_id: int, employee_id: int):
         except AgencyEmployee.DoesNotExist:
             return Response({'success': False, 'error': 'Employee not found'}, status=404)
         
+        # Verify the employee belongs to the authenticated agency
+        if employee.agency_id != user.id:
+            return Response({
+                'success': False,
+                'error': 'This employee does not belong to your agency'
+            }, status=403)
+        
         # Verify job was assigned to this agency
-        if job.assignedAgencyFK_id != employee.agency_id:
+        if job.assignedAgencyFK_id != user.id:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'
@@ -3657,8 +3664,15 @@ def mark_employee_checkout(request, job_id: int, employee_id: int):
         except AgencyEmployee.DoesNotExist:
             return Response({'success': False, 'error': 'Employee not found'}, status=404)
         
+        # Verify the employee belongs to the authenticated agency
+        if employee.agency_id != user.id:
+            return Response({
+                'success': False,
+                'error': 'This employee does not belong to your agency'
+            }, status=403)
+        
         # Verify job was assigned to this agency
-        if job.assignedAgencyFK_id != employee.agency_id:
+        if job.assignedAgencyFK_id != user.id:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'


### PR DESCRIPTION
Fixes 403 error when agency tries to mark arrival for their own employees.

**Root cause:** Previous validation only checked if job.assignedAgencyFK_id == employee.agency_id but did NOT verify that the authenticated user owns that agency.

**Example failure scenario:**
- User downtown@gmail.com (ID 15) is authenticated
- Employee 19 belongs to agency 999 
- Job 24 is assigned to agency 999
- Previous code: ✓ Pass (999 == 999)
- But user 15 doesn't own agency 999! ❌

**Fix applied to both endpoints:**
1. **mark_employee_arrival**: Added mployee.agency_id == user.id AND job.assignedAgencyFK_id == user.id checks
2. **mark_employee_checkout**: Same validation

Now properly verifies authenticated user owns the agency before allowing attendance operations.