### PR TITLE
fix: add missing hook imports to mobile job detail screen

### DIFF
--- a/apps/frontend_mobile/iayos_mobile/app/jobs/[id].tsx
+++ b/apps/frontend_mobile/iayos_mobile/app/jobs/[id].tsx
@@ -37,6 +37,8 @@ import {
   useTeamJobApplications,
   useAcceptTeamApplication,
   useRejectTeamApplication,
+  useWorkerCompleteAssignment,
+  useClientApproveTeamJob,
   type SkillSlot,
   type WorkerAssignment,
 } from "@/lib/hooks/useTeamJob";


### PR DESCRIPTION
Fixes crash when viewing job details after creating a daily job. Two hooks were used but never imported in app/jobs/[id].tsx: useWorkerCompleteAssignment and useClientApproveTeamJob. This caused ReferenceError when the component rendered, showing 'Something went wrong' error.