### PR TITLE
Fix: Agency Job Validation Bug in Daily Attendance Endpoints

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -3567,7 +3567,7 @@ def mark_employee_arrival(request, job_id: int, employee_id: int):
             }, status=403)
         
         # Verify job was assigned to this agency
-        if job.assignedAgencyFK_id != user.id:
+        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.id:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'
@@ -3672,7 +3672,7 @@ def mark_employee_checkout(request, job_id: int, employee_id: int):
             }, status=403)
         
         # Verify job was assigned to this agency
-        if job.assignedAgencyFK_id != user.id:
+        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.id:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'


### PR DESCRIPTION
## Bug Description

Fixed critical bug in agency daily attendance endpoints where job validation was comparing wrong IDs:

- **Bug**: job.assignedAgencyFK_id != user.id compared Agency.agencyId to Accounts.accountID
- **Error**: Caused Internal Server Error when agencies tried to mark employee arrival/checkout
- **Root Cause**: Different models with different ID sequences

## Solution

Changed validation to traverse relationship correctly:
`python
if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.id:
``n
This correctly checks: Job -> Agency -> Accounts

## Affected Endpoints
- POST /api/agency/jobs/{job_id}/daily/mark-arrival (line 3570)
- POST /api/agency/jobs/{job_id}/daily/mark-checkout (line 3675)

## Testing
- [x] Identified both occurrences
- [x] Applied fix to both endpoints
- [ ] Manual testing required with real agency/employee/job

## Impact
- Fixes broken agency daily attendance feature
- No database migration needed
- Backward compatible (just fixes validation logic)