### PR TITLE
Fix: Accounts Model Attribute Usage in Agency Daily Attendance

### DIFF
--- a/apps/backend/src/agency/api.py
+++ b/apps/backend/src/agency/api.py
@@ -3560,14 +3560,14 @@ def mark_employee_arrival(request, job_id: int, employee_id: int):
             return Response({'success': False, 'error': 'Employee not found'}, status=404)
         
         # Verify the employee belongs to the authenticated agency
-        if employee.agency_id != user.id:
+        if employee.agency_id != user.accountID:
             return Response({
                 'success': False,
                 'error': 'This employee does not belong to your agency'
             }, status=403)
         
         # Verify job was assigned to this agency
-        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.id:
+        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.accountID:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'
@@ -3665,14 +3665,14 @@ def mark_employee_checkout(request, job_id: int, employee_id: int):
             return Response({'success': False, 'error': 'Employee not found'}, status=404)
         
         # Verify the employee belongs to the authenticated agency
-        if employee.agency_id != user.id:
+        if employee.agency_id != user.accountID:
             return Response({
                 'success': False,
                 'error': 'This employee does not belong to your agency'
             }, status=403)
         
         # Verify job was assigned to this agency
-        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.id:
+        if not job.assignedAgencyFK or job.assignedAgencyFK.accountFK_id != user.accountID:
             return Response({
                 'success': False,
                 'error': 'This job is not assigned to your agency'


### PR DESCRIPTION
## Bug Description

Fixed critical AttributeError in agency daily attendance endpoints:

Error: AttributeError: 'Accounts' object has no attribute 'id'
Occurred at lines 3563, 3570, 3668, 3675 in agency/api.py

## Root Cause

The Accounts model uses accountID as its primary key field, not id.
When request.auth returns an Accounts object, accessing user.id raises AttributeError.

## Solution

Changed all 4 instances from user.id to user.accountID:

**mark_employee_arrival function (lines 3563, 3570)**:
- Line 3563: Employee ownership validation
- Line 3570: Job assignment validation

**mark_employee_checkout function (lines 3668, 3675)**:
- Line 3668: Employee ownership validation
- Line 3675: Job assignment validation

## Verification

- [x] Comprehensive scan of entire agency/api.py file
- [x] Confirmed these are the ONLY 4 instances of this error
- [x] All 4 fixes follow identical pattern
- [ ] Manual testing required with real agency/employee/job

## Impact

- Fixes Internal Server Error (500) when marking employee attendance
- Agencies can now successfully mark employee arrivals and checkouts
- No database migration needed
- Backward compatible (fixes existing validation logic)